### PR TITLE
Use hatchling dynamic versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "katsustats"
-version = "0.1.0"
+dynamic = ["version"]
 description = "A modernized backtest report module powered by Polars"
 readme = "README.md"
 authors = [
@@ -23,6 +23,9 @@ target-version = "py39"
 [tool.ruff.lint]
 select = ["E", "W", "F", "I", "UP"]
 ignore = ["E501"]
+
+[tool.hatch.version]
+path = "src/katsustats/__init__.py"
 
 [build-system]
 requires = ["hatchling"]

--- a/uv.lock
+++ b/uv.lock
@@ -438,7 +438,6 @@ wheels = [
 
 [[package]]
 name = "katsustats"
-version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Summary
- Replaces hardcoded `version = "0.1.0"` in `pyproject.toml` with `dynamic = ["version"]`
- Adds `[tool.hatch.version]` pointing to `src/katsustats/__init__.py` as the single source of truth
- Eliminates the risk of version strings getting out of sync between the two files

## Test plan
- [ ] CI passes (ruff + pytest)
- [ ] `uv run python -c "import katsustats; print(katsustats.__version__)"` prints `0.1.0`
- [ ] `uv build` produces a correctly versioned artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)