### PR TITLE
Add PyPI metadata (license, classifiers, URLs)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,12 +6,31 @@ readme = "README.md"
 authors = [
     { name = "katsu1110", email = "code1110g-show@hotmail.co.jp" }
 ]
+license = "Apache-2.0"
 requires-python = ">=3.9"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Financial and Insurance Industry",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Office/Business :: Financial :: Investment",
+    "Typing :: Typed",
+]
 dependencies = [
     "polars>=1.0.0",
     "numpy>=1.24.0",
     "matplotlib>=3.7.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/katsu1110/katsustats"
+Repository = "https://github.com/katsu1110/katsustats"
+Issues = "https://github.com/katsu1110/katsustats/issues"
 
 [dependency-groups]
 dev = ["pytest>=8.0", "ruff>=0.4"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 authors = [
     { name = "katsu1110", email = "code1110g-show@hotmail.co.jp" }
 ]
-license = "Apache-2.0"
+license = { text = "Apache-2.0" }
 requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
## Summary
- Adds `license = "Apache-2.0"` field
- Adds `classifiers` for discoverability on PyPI (dev status, audience, license, Python versions, topic, typing)
- Adds `[project.urls]` for homepage, repository, and issues links on the PyPI page

## Test plan
- [ ] CI passes (ruff + pytest)
- [ ] `uv build` produces a correctly versioned artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)