### PR TITLE
Quick wins: correctness fixes, Polars rolling rewrite, flat re-exports, verbose flag

### DIFF
--- a/src/katsustats/__init__.py
+++ b/src/katsustats/__init__.py
@@ -5,8 +5,104 @@ Usage:
     import katsustats
     katsustats.reports.full(pnl, base_pnl)              # console + plots
     katsustats.reports.html(pnl, output="report.html")   # HTML report
+
+    # Flat imports also work:
+    from katsustats import sharpe, plot_cumulative_returns, html
 """
+
+from __future__ import annotations
 
 from . import plots, reports, stats  # noqa: F401
 
+# plots
+from .plots import (
+    plot_cumulative_returns,
+    plot_dow_returns,
+    plot_drawdown,
+    plot_monthly_heatmap,
+    plot_return_distribution,
+    plot_rolling_sharpe,
+    plot_rolling_volatility,
+    plot_yearly_returns,
+)
+
+# reports
+from .reports import full, html
+
+# stats
+from .stats import (
+    alpha_beta,
+    avg_loss,
+    avg_win,
+    best_day,
+    cagr,
+    calmar,
+    correlation,
+    day_of_week_stats,
+    drawdown_details,
+    excess_return,
+    information_ratio,
+    kurtosis,
+    max_drawdown,
+    profit_factor,
+    recovery_factor,
+    rolling_sharpe,
+    rolling_volatility,
+    sharpe,
+    skewness,
+    sortino,
+    summary_metrics,
+    total_return,
+    value_at_risk,
+    volatility,
+    win_rate,
+    worst_day,
+)
+
 __version__ = "0.1.0"
+
+__all__ = [
+    # submodules
+    "plots",
+    "reports",
+    "stats",
+    # stats
+    "alpha_beta",
+    "avg_loss",
+    "avg_win",
+    "best_day",
+    "cagr",
+    "calmar",
+    "correlation",
+    "day_of_week_stats",
+    "drawdown_details",
+    "excess_return",
+    "information_ratio",
+    "kurtosis",
+    "max_drawdown",
+    "profit_factor",
+    "recovery_factor",
+    "rolling_sharpe",
+    "rolling_volatility",
+    "sharpe",
+    "skewness",
+    "sortino",
+    "summary_metrics",
+    "total_return",
+    "value_at_risk",
+    "volatility",
+    "win_rate",
+    "worst_day",
+    # plots
+    "plot_cumulative_returns",
+    "plot_dow_returns",
+    "plot_drawdown",
+    "plot_monthly_heatmap",
+    "plot_return_distribution",
+    "plot_rolling_sharpe",
+    "plot_rolling_volatility",
+    "plot_yearly_returns",
+    # reports
+    "full",
+    "html",
+]

--- a/src/katsustats/_dataframe.py
+++ b/src/katsustats/_dataframe.py
@@ -22,7 +22,10 @@ def ensure_polars(df: Any, name: str = "df") -> pl.DataFrame:
     if isinstance(df, pl.DataFrame):
         polars_df = df
     elif _is_pandas_dataframe(df):
-        polars_df = pl.DataFrame({col: df[col].tolist() for col in df.columns})
+        try:
+            polars_df = pl.from_pandas(df)
+        except ImportError:
+            polars_df = pl.DataFrame({col: df[col].tolist() for col in df.columns})
     else:
         raise TypeError(
             f"{name} must be a Polars or pandas DataFrame, got {type(df).__name__}"

--- a/src/katsustats/reports.py
+++ b/src/katsustats/reports.py
@@ -295,6 +295,7 @@ def full(
     figsize_main: tuple = (12, 5),
     figsize_small: tuple = (12, 4),
     show: bool = True,
+    verbose: bool = True,
 ) -> dict:
     """
     Generate a full backtest report with metrics and plots.
@@ -307,6 +308,7 @@ def full(
         figsize_main: Figure size for main charts.
         figsize_small: Figure size for smaller charts.
         show: Whether to display plots inline (default True).
+        verbose: Whether to print metric tables to stdout (default True).
 
     Returns:
         dict with keys: "metrics", "drawdowns", "dow_stats", "figures"
@@ -330,16 +332,18 @@ def full(
 
     # ── 1. Metrics Summary ──────────────────────────────────────────
     metrics = stats.summary_metrics(pnl, base_pnl, rf, periods)
-    _print_df(metrics, "Performance Metrics")
+    if verbose:
+        _print_df(metrics, "Performance Metrics")
 
     # ── 2. Top Drawdowns ────────────────────────────────────────────
     dd = stats.drawdown_details(pnl)
-    if dd.height > 0:
+    if verbose and dd.height > 0:
         _print_df(dd, "Top 5 Drawdowns")
 
     # ── 3. Day-of-Week Stats ────────────────────────────────────────
     dow = stats.day_of_week_stats(pnl)
-    _print_df(dow, "Day-of-Week Statistics")
+    if verbose:
+        _print_df(dow, "Day-of-Week Statistics")
 
     # ── 4. Plots ────────────────────────────────────────────────────
     figures: dict[str, plt.Figure] = {}

--- a/src/katsustats/stats.py
+++ b/src/katsustats/stats.py
@@ -83,13 +83,11 @@ def sortino(df: DataFrameLike, rf: float = 0.0, periods: int = 252) -> float:
     r = _to_returns(df)
     rf_per_period = rf / periods
     excess = r - rf_per_period
-    downside = excess.filter(excess < 0)
-    if downside.len() == 0:
+    # Downside deviation: RMS of min(excess, 0) over ALL days (not just negative ones)
+    downside_sq_mean = (excess.clip(upper_bound=0.0) ** 2).mean()
+    if downside_sq_mean is None or downside_sq_mean == 0.0:
         return float("inf")
-    downside_std = float((downside**2).mean() ** 0.5)
-    if downside_std == 0:
-        return 0.0
-    return float(excess.mean() / downside_std * np.sqrt(periods))
+    return float(excess.mean() / (downside_sq_mean**0.5) * np.sqrt(periods))
 
 
 def max_drawdown(df: DataFrameLike) -> float:
@@ -193,7 +191,7 @@ def drawdown_details(df: DataFrameLike, top_n: int = 5) -> pl.DataFrame:
     duration in days.
 
     Returns a Polars DataFrame with columns:
-        [start, trough, recovery, max_dd, days]
+        [start, trough, recovery, max_dd, drawdown_days, recovery_days]
     """
     df = ensure_polars(df)
     r = _to_returns(df)
@@ -228,7 +226,10 @@ def drawdown_details(df: DataFrameLike, top_n: int = 5) -> pl.DataFrame:
                     if recovery_idx is not None
                     else None,
                     "max_dd": min_dd,
-                    "days": (trough_idx - start_idx),
+                    "drawdown_days": (trough_idx - start_idx),
+                    "recovery_days": (recovery_idx - trough_idx)
+                    if recovery_idx is not None
+                    else None,
                 }
             )
         else:
@@ -241,7 +242,8 @@ def drawdown_details(df: DataFrameLike, top_n: int = 5) -> pl.DataFrame:
                 "trough": pl.Series([], dtype=pl.Date),
                 "recovery": pl.Series([], dtype=pl.Date),
                 "max_dd": pl.Series([], dtype=pl.Float64),
-                "days": pl.Series([], dtype=pl.Int64),
+                "drawdown_days": pl.Series([], dtype=pl.Int64),
+                "recovery_days": pl.Series([], dtype=pl.Int64),
             }
         )
 
@@ -259,10 +261,11 @@ def alpha_beta(
     df: DataFrameLike, base_df: DataFrameLike, periods: int = 252
 ) -> tuple[float, float]:
     """Annualized alpha and beta vs benchmark using OLS."""
-    r = _to_returns(df).to_numpy()
-    b = _to_returns(base_df).to_numpy()
-    min_len = min(len(r), len(b))
-    r, b = r[:min_len], b[:min_len]
+    df = ensure_polars(df)
+    base_df = ensure_polars(base_df, "base_df")
+    joined = df.join(base_df.rename({"pnl": "_base_pnl"}), on="date", how="inner")
+    r = joined.get_column("pnl").to_numpy()
+    b = joined.get_column("_base_pnl").to_numpy()
 
     cov = np.cov(r, b)
     var_b = cov[1, 1]
@@ -270,26 +273,28 @@ def alpha_beta(
         return 0.0, 0.0
     beta = float(cov[0, 1] / var_b)
     alpha_daily = float(np.mean(r) - beta * np.mean(b))
-    alpha_annual = (1 + alpha_daily) ** periods - 1
+    alpha_annual = alpha_daily * periods
     return alpha_annual, beta
 
 
 def correlation(df: DataFrameLike, base_df: DataFrameLike) -> float:
     """Pearson correlation between strategy and benchmark returns."""
-    r = _to_returns(df).to_numpy()
-    b = _to_returns(base_df).to_numpy()
-    min_len = min(len(r), len(b))
-    return float(np.corrcoef(r[:min_len], b[:min_len])[0, 1])
+    df = ensure_polars(df)
+    base_df = ensure_polars(base_df, "base_df")
+    joined = df.join(base_df.rename({"pnl": "_base_pnl"}), on="date", how="inner")
+    r = joined.get_column("pnl").to_numpy()
+    b = joined.get_column("_base_pnl").to_numpy()
+    return float(np.corrcoef(r, b)[0, 1])
 
 
 def information_ratio(
     df: DataFrameLike, base_df: DataFrameLike, periods: int = 252
 ) -> float:
     """Annualized information ratio (excess return / tracking error)."""
-    r = _to_returns(df)
-    b = _to_returns(base_df)
-    min_len = min(r.len(), b.len())
-    excess = r.head(min_len) - b.head(min_len)
+    df = ensure_polars(df)
+    base_df = ensure_polars(base_df, "base_df")
+    joined = df.join(base_df.rename({"pnl": "_base_pnl"}), on="date", how="inner")
+    excess = joined.get_column("pnl") - joined.get_column("_base_pnl")
     te = float(excess.std())
     if te == 0:
         return 0.0
@@ -346,24 +351,20 @@ def rolling_sharpe(
 ) -> pl.DataFrame:
     """Rolling Sharpe ratio over a given window."""
     df = ensure_polars(df)
-    r = _to_returns(df)
-    dates = df.get_column("date")
-
-    r_np = r.to_numpy().astype(np.float64)
-    n = len(r_np)
-    sharpe_vals = np.full(n, np.nan)
-
-    for i in range(window, n):
-        chunk = r_np[i - window : i]
-        std = chunk.std(ddof=1)
-        if std > 0:
-            sharpe_vals[i] = (chunk.mean() / std) * np.sqrt(periods)
-
-    return pl.DataFrame(
-        {
-            "date": dates,
-            "rolling_sharpe": sharpe_vals,
-        }
+    return (
+        df.sort("date")
+        .with_columns(
+            [
+                pl.col("pnl").rolling_mean(window_size=window).alias("_rm"),
+                pl.col("pnl").rolling_std(window_size=window, ddof=1).alias("_rs"),
+            ]
+        )
+        .with_columns(
+            pl.when(pl.col("_rs") > 0)
+            .then(pl.col("_rm") / pl.col("_rs") * float(periods**0.5))
+            .alias("rolling_sharpe")
+        )
+        .select(["date", "rolling_sharpe"])
     )
 
 
@@ -372,22 +373,15 @@ def rolling_volatility(
 ) -> pl.DataFrame:
     """Rolling annualized volatility over a given window."""
     df = ensure_polars(df)
-    r = _to_returns(df)
-    dates = df.get_column("date")
-
-    r_np = r.to_numpy().astype(np.float64)
-    n = len(r_np)
-    vol_vals = np.full(n, np.nan)
-
-    for i in range(window, n):
-        chunk = r_np[i - window : i]
-        vol_vals[i] = chunk.std(ddof=1) * np.sqrt(periods)
-
-    return pl.DataFrame(
-        {
-            "date": dates,
-            "rolling_vol": vol_vals,
-        }
+    return (
+        df.sort("date")
+        .with_columns(
+            (
+                pl.col("pnl").rolling_std(window_size=window, ddof=1)
+                * float(periods**0.5)
+            ).alias("rolling_vol")
+        )
+        .select(["date", "rolling_vol"])
     )
 
 

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -80,6 +80,16 @@ class TestFull:
         )
         assert isinstance(result["metrics"], pl.DataFrame)
 
+    def test_verbose_false_suppresses_stdout(self, sample_df, capsys):
+        reports.full(sample_df, show=False, verbose=False)
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
+    def test_verbose_true_prints_output(self, sample_df, capsys):
+        reports.full(sample_df, show=False, verbose=True)
+        captured = capsys.readouterr()
+        assert len(captured.out) > 0
+
 
 # ---------------------------------------------------------------------------
 # reports.html

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -89,6 +89,27 @@ class TestSortino:
     def test_all_negative_negative_sortino(self, all_negative_df):
         assert stats.sortino(all_negative_df) < 0
 
+    def test_known_value_uses_all_day_denominator(self):
+        """Regression: denominator is RMS of min(excess,0) over ALL days."""
+        df = pl.DataFrame(
+            {
+                "date": [
+                    "2023-01-02",
+                    "2023-01-03",
+                    "2023-01-04",
+                    "2023-01-05",
+                    "2023-01-06",
+                ],
+                "pnl": [0.02, 0.01, 0.03, -0.01, -0.02],
+            }
+        ).with_columns(pl.col("date").cast(pl.Date))
+        # clip upper=0: [0, 0, 0, -0.01, -0.02]
+        # sq_mean = (0 + 0 + 0 + 0.0001 + 0.0004) / 5 = 0.0001
+        # downside_std = 0.01; mean = 0.006
+        # sortino = 0.006 / 0.01 * sqrt(252)
+        expected = 0.6 * math.sqrt(252)
+        assert abs(stats.sortino(df, rf=0.0, periods=252) - expected) < 1e-8
+
 
 class TestMaxDrawdown:
     def test_returns_float(self, sample_df):
@@ -216,7 +237,14 @@ class TestDrawdownDetails:
 
     def test_schema(self, sample_df):
         dd = stats.drawdown_details(sample_df)
-        assert set(dd.columns) == {"start", "trough", "recovery", "max_dd", "days"}
+        assert set(dd.columns) == {
+            "start",
+            "trough",
+            "recovery",
+            "max_dd",
+            "drawdown_days",
+            "recovery_days",
+        }
 
     def test_max_dd_negative(self, sample_df):
         dd = stats.drawdown_details(sample_df)
@@ -230,6 +258,17 @@ class TestDrawdownDetails:
     def test_no_drawdown_empty(self, all_positive_df):
         dd = stats.drawdown_details(all_positive_df)
         assert dd.height == 0
+
+    def test_drawdown_days_non_negative(self, sample_df):
+        dd = stats.drawdown_details(sample_df)
+        if dd.height > 0:
+            assert all(v >= 0 for v in dd.get_column("drawdown_days").to_list())
+
+    def test_recovery_days_non_negative_when_not_null(self, sample_df):
+        dd = stats.drawdown_details(sample_df)
+        if dd.height > 0:
+            vals = dd.get_column("recovery_days").to_list()
+            assert all(v is None or v >= 0 for v in vals)
 
 
 class TestDayOfWeekStats:
@@ -274,8 +313,8 @@ class TestRollingSharpe:
         window = 5
         result = stats.rolling_sharpe(sample_df, window=window)
         vals = result.get_column("rolling_sharpe").to_list()
-        # First `window` values should be NaN
-        assert all(v is None or math.isnan(v) for v in vals[:window])
+        # Standard trailing window: first window-1 positions are null
+        assert all(v is None or math.isnan(v) for v in vals[: window - 1])
 
 
 class TestRollingVolatility:
@@ -316,10 +355,23 @@ class TestAlphaBeta:
         assert isinstance(beta, float)
 
     def test_unequal_lengths(self, sample_df, benchmark_df):
-        # Should not raise; truncates to min length
+        # Should not raise; inner-joins on date so shorter series limits rows used
         shorter = benchmark_df.head(10)
         alpha, beta = stats.alpha_beta(sample_df, shorter)
         assert isinstance(alpha, float)
+
+    def test_alpha_uses_linear_annualization(self, sample_df, benchmark_df):
+        """Regression: alpha_annual = alpha_daily * periods (not compound)."""
+        import numpy as np
+
+        alpha, beta = stats.alpha_beta(sample_df, benchmark_df)
+        r = sample_df.get_column("pnl").to_numpy()
+        b = benchmark_df.get_column("pnl").to_numpy()
+        cov = np.cov(r, b)
+        beta_raw = cov[0, 1] / cov[1, 1]
+        alpha_daily = float(np.mean(r) - beta_raw * np.mean(b))
+        expected = alpha_daily * 252
+        assert abs(alpha - expected) < 1e-10
 
 
 class TestCorrelation:


### PR DESCRIPTION
## Summary

- **Fix Sortino formula** — denominator was computed over negative-only days; now uses standard downside deviation: `sqrt(mean(min(excess,0)²))` over all days
- **Fix alpha annualization** — compound `(1+α)^periods − 1` replaced with linear `α × periods`, matching quantstats and textbooks
- **Fix benchmark date alignment** — `alpha_beta`, `correlation`, `information_ratio` now inner-join on `date` instead of silently truncating with `head(min_len)`
- **`drawdown_details` schema** — rename `days` → `drawdown_days`; add `recovery_days` (trough→recovery) column
- **Rolling metrics rewrite** — `rolling_sharpe` / `rolling_volatility` replaced Python for-loops with Polars `rolling_mean` / `rolling_std` expressions (O(n) vs O(n·window))
- **Flat re-exports + `__all__`** — `from katsustats import sharpe, plot_cumulative_returns, html` now works
- **`verbose` flag on `reports.full()`** — pass `verbose=False` to suppress all `_print_df` stdout output (useful in CI / notebooks)
- **`pl.from_pandas` upgrade** — tries the pyarrow-backed fast path; falls back to `.tolist()` if pyarrow is absent

## Test plan

- [x] 129 tests pass (`uv run pytest tests/ -v`)
- [x] Ruff lint + format clean (`uv run ruff check src/ tests/`)
- [x] New Sortino known-value regression test verifying exact formula
- [x] New alpha linear-scaling regression test
- [x] Updated drawdown schema assertion for renamed + new columns
- [x] Updated rolling NaN test to trailing-window convention (`window-1` nulls)
- [x] `verbose=False` / `verbose=True` round-trip tests

## Related issues

Closes parts of #19 (correctness fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)