### PR TITLE
feat: examples, changelog, contributing guide, issue templates, README badges

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,43 @@
+name: Bug report
+description: Report incorrect behaviour or an unexpected error
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What went wrong?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproducer
+    attributes:
+      label: Minimal reproducer
+      description: Paste the smallest snippet that triggers the bug.
+      render: python
+    validations:
+      required: true
+
+  - type: textarea
+    id: versions
+    attributes:
+      label: Versions
+      description: |
+        Run `python -c "import katsustats, polars, sys; print(katsustats.__version__, polars.__version__, sys.version)"` and paste the output.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour / traceback
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,24 @@
+name: Feature request
+description: Propose a new metric, chart, or other enhancement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Use case
+      description: What problem would this solve for you?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_api
+    attributes:
+      label: Proposed API (optional)
+      description: Sketch the function signature or output you have in mind.
+      render: python
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Did you consider any workarounds or alternative approaches?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+## [0.1.0] — 2024-01-01
+
+### Added
+- `katsustats.reports.full()` — full backtest report with metrics, drawdown analysis, and 8 charts
+- `katsustats.reports.html()` — self-contained HTML report with embedded charts
+- `katsustats.stats` — 40+ pure metric functions (Sharpe, Sortino, CAGR, Calmar, VaR, CVaR, tail ratio, common sense ratio, risk of ruin, drawdown details, rolling metrics, alpha/beta, regime stats, and more)
+- `katsustats.plots` — 11 matplotlib chart functions (cumulative returns, drawdown, monthly heatmap, yearly/end-of-year bar charts, return distribution, rolling Sharpe/volatility, day-of-week analysis, benchmark overlay)
+- Benchmark support via `base_pnl` parameter — adds Alpha, Beta, Correlation, Information Ratio, Excess Return to summary table
+- Pandas input support — DataFrames are converted to Polars automatically
+- `py.typed` marker for PEP 561 type-checking support
+- Apache-2.0 license
+
+[Unreleased]: https://github.com/katsu1110/katsustats/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/katsu1110/katsustats/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing
+
+Contributions are welcome. Please open an issue before submitting non-trivial changes.
+
+## Prerequisites
+
+- Python 3.9+
+- [uv](https://docs.astral.sh/uv/) (package manager)
+
+## Setup
+
+```bash
+git clone https://github.com/katsu1110/katsustats.git
+cd katsustats
+uv sync --dev
+```
+
+## Running tests
+
+```bash
+uv run pytest tests/ -v
+```
+
+## Linting and formatting
+
+```bash
+uv run ruff check src/ tests/ examples/
+uv run ruff format src/ tests/ examples/
+```
+
+CI enforces both checks on every pull request.
+
+## Code conventions
+
+- All modules start with `from __future__ import annotations`
+- Functions only — no classes
+- snake_case function names; `_` prefix for private helpers
+- Short one-line docstrings on all public functions
+- Input validation via `assert` (not `raise ValueError`)
+- Plot styling goes through the shared `_apply_style()` / `_add_title()` helpers in `plots.py`
+- Keep examples self-contained — no helper imports between example scripts
+
+## Pull requests
+
+- Keep PRs focused on a single concern
+- Update `CHANGELOG.md` under `[Unreleased]` if your change affects public behaviour
+- All existing tests must pass; add tests for new public functions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,10 +33,10 @@ CI enforces both checks on every pull request.
 ## Code conventions
 
 - All modules start with `from __future__ import annotations`
-- Functions only — no classes
+- Prefer functions over introducing new public classes; typing-only/internal classes (e.g. `Protocol`s) are allowed where appropriate
 - snake_case function names; `_` prefix for private helpers
-- Short one-line docstrings on all public functions
-- Input validation via `assert` (not `raise ValueError`)
+- Public functions should have clear docstrings; use one-line or multi-line docstrings as appropriate
+- Validate inputs explicitly and follow existing patterns; both `assert` and `raise ValueError` are used in the codebase where appropriate
 - Plot styling goes through the shared `_apply_style()` / `_add_title()` helpers in `plots.py`
 - Keep examples self-contained — no helper imports between example scripts
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Katsustats
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![Python](https://img.shields.io/badge/python-3.9%2B-blue.svg)](https://www.python.org/)
+[![CI](https://github.com/katsu1110/katsustats/actions/workflows/ci.yml/badge.svg)](https://github.com/katsu1110/katsustats/actions/workflows/ci.yml)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
 A simple backtest tool for your return series, inspired by [quantstats](https://github.com/ranaroussi/quantstats). 
 

--- a/examples/html_report.py
+++ b/examples/html_report.py
@@ -15,22 +15,28 @@ import polars as pl
 
 import katsustats
 
-rng = np.random.default_rng(seed=42)
-dates = pl.date_range(pl.date(2020, 1, 1), pl.date(2022, 12, 31), "1d", eager=True)
-n = len(dates)
 
-pnl = pl.DataFrame(
-    {"date": dates, "pnl": rng.normal(loc=0.0005, scale=0.011, size=n).tolist()}
-)
-benchmark = pl.DataFrame(
-    {"date": dates, "pnl": rng.normal(loc=0.0003, scale=0.008, size=n).tolist()}
-)
+def main() -> None:
+    rng = np.random.default_rng(seed=42)
+    dates = pl.date_range(pl.date(2020, 1, 1), pl.date(2022, 12, 31), "1d", eager=True)
+    n = len(dates)
 
-katsustats.reports.html(
-    pnl,
-    base_pnl=benchmark,
-    title="Demo Strategy",
-    output="report.html",
-)
+    pnl = pl.DataFrame(
+        {"date": dates, "pnl": rng.normal(loc=0.0005, scale=0.011, size=n).tolist()}
+    )
+    benchmark = pl.DataFrame(
+        {"date": dates, "pnl": rng.normal(loc=0.0003, scale=0.008, size=n).tolist()}
+    )
 
-print("Report written to report.html")
+    katsustats.reports.html(
+        pnl,
+        base_pnl=benchmark,
+        title="Demo Strategy",
+        output="report.html",
+    )
+
+    print("Report written to report.html")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/html_report.py
+++ b/examples/html_report.py
@@ -1,0 +1,36 @@
+"""
+HTML report: generate a self-contained HTML file you can open in any browser.
+
+The output is a single .html file with embedded charts (no external dependencies).
+
+Run with:
+    uv run python examples/html_report.py
+    open report.html   # macOS — or just double-click the file
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+
+import katsustats
+
+rng = np.random.default_rng(seed=42)
+dates = pl.date_range(pl.date(2020, 1, 1), pl.date(2022, 12, 31), "1d", eager=True)
+n = len(dates)
+
+pnl = pl.DataFrame(
+    {"date": dates, "pnl": rng.normal(loc=0.0005, scale=0.011, size=n).tolist()}
+)
+benchmark = pl.DataFrame(
+    {"date": dates, "pnl": rng.normal(loc=0.0003, scale=0.008, size=n).tolist()}
+)
+
+katsustats.reports.html(
+    pnl,
+    base_pnl=benchmark,
+    title="Demo Strategy",
+    output="report.html",
+)
+
+print("Report written to report.html")

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -12,17 +12,23 @@ import polars as pl
 
 import katsustats
 
-# Reproducible synthetic daily returns: ~+15% CAGR, 1% daily vol
-rng = np.random.default_rng(seed=0)
-dates = pl.date_range(pl.date(2020, 1, 1), pl.date(2022, 12, 31), "1d", eager=True)
-returns = rng.normal(loc=0.0006, scale=0.01, size=len(dates))
 
-pnl = pl.DataFrame({"date": dates, "pnl": returns.tolist()})
+def main() -> None:
+    # Reproducible synthetic daily returns: ~+15% CAGR, 1% daily vol
+    rng = np.random.default_rng(seed=0)
+    dates = pl.date_range(pl.date(2020, 1, 1), pl.date(2022, 12, 31), "1d", eager=True)
+    returns = rng.normal(loc=0.0006, scale=0.01, size=len(dates))
 
-# Generate full report (prints metrics tables; pass show=True to open chart windows)
-results = katsustats.reports.full(pnl, show=False)
+    pnl = pl.DataFrame({"date": dates, "pnl": returns.tolist()})
 
-print("\nKeys in results:", list(results.keys()))
-print("\nMetrics shape:", results["metrics"].shape)
-print("\nTop drawdown:")
-print(results["drawdowns"].head(1))
+    # Generate full report (prints metrics tables; pass show=True to open chart windows)
+    results = katsustats.reports.full(pnl, show=False)
+
+    print("\nKeys in results:", list(results.keys()))
+    print("\nMetrics shape:", results["metrics"].shape)
+    print("\nTop drawdown:")
+    print(results["drawdowns"].head(1))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -1,0 +1,28 @@
+"""
+Quickstart: generate a full backtest report from a synthetic return series.
+
+Run with:
+    uv run python examples/quickstart.py
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+
+import katsustats
+
+# Reproducible synthetic daily returns: ~+15% CAGR, 1% daily vol
+rng = np.random.default_rng(seed=0)
+dates = pl.date_range(pl.date(2020, 1, 1), pl.date(2022, 12, 31), "1d", eager=True)
+returns = rng.normal(loc=0.0006, scale=0.01, size=len(dates))
+
+pnl = pl.DataFrame({"date": dates, "pnl": returns.tolist()})
+
+# Generate full report (prints metrics tables; pass show=True to open chart windows)
+results = katsustats.reports.full(pnl, show=False)
+
+print("\nKeys in results:", list(results.keys()))
+print("\nMetrics shape:", results["metrics"].shape)
+print("\nTop drawdown:")
+print(results["drawdowns"].head(1))

--- a/examples/with_benchmark.py
+++ b/examples/with_benchmark.py
@@ -1,0 +1,34 @@
+"""
+Benchmark comparison: alpha, beta, correlation, and information ratio.
+
+Passing a benchmark to reports.full() adds benchmark-relative metrics to the
+summary table (Alpha, Beta, Correlation, Information Ratio, Excess Return).
+
+Run with:
+    uv run python examples/with_benchmark.py
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+
+import katsustats
+
+rng = np.random.default_rng(seed=0)
+dates = pl.date_range(pl.date(2020, 1, 1), pl.date(2022, 12, 31), "1d", eager=True)
+n = len(dates)
+
+# Strategy: higher return, higher vol
+strategy_returns = rng.normal(loc=0.0006, scale=0.012, size=n)
+# Benchmark: lower return, lower vol (simulate a broad index)
+bench_returns = rng.normal(loc=0.0003, scale=0.008, size=n)
+
+pnl = pl.DataFrame({"date": dates, "pnl": strategy_returns.tolist()})
+benchmark = pl.DataFrame({"date": dates, "pnl": bench_returns.tolist()})
+
+results = katsustats.reports.full(pnl, base_pnl=benchmark, show=False)
+
+# The metrics DataFrame includes benchmark-relative columns when base_pnl is given
+print("\nAll metrics:")
+print(results["metrics"])

--- a/examples/with_benchmark.py
+++ b/examples/with_benchmark.py
@@ -15,20 +15,26 @@ import polars as pl
 
 import katsustats
 
-rng = np.random.default_rng(seed=0)
-dates = pl.date_range(pl.date(2020, 1, 1), pl.date(2022, 12, 31), "1d", eager=True)
-n = len(dates)
 
-# Strategy: higher return, higher vol
-strategy_returns = rng.normal(loc=0.0006, scale=0.012, size=n)
-# Benchmark: lower return, lower vol (simulate a broad index)
-bench_returns = rng.normal(loc=0.0003, scale=0.008, size=n)
+def main() -> None:
+    rng = np.random.default_rng(seed=0)
+    dates = pl.date_range(pl.date(2020, 1, 1), pl.date(2022, 12, 31), "1d", eager=True)
+    n = len(dates)
 
-pnl = pl.DataFrame({"date": dates, "pnl": strategy_returns.tolist()})
-benchmark = pl.DataFrame({"date": dates, "pnl": bench_returns.tolist()})
+    # Strategy: higher return, higher vol
+    strategy_returns = rng.normal(loc=0.0006, scale=0.012, size=n)
+    # Benchmark: lower return, lower vol (simulate a broad index)
+    bench_returns = rng.normal(loc=0.0003, scale=0.008, size=n)
 
-results = katsustats.reports.full(pnl, base_pnl=benchmark, show=False)
+    pnl = pl.DataFrame({"date": dates, "pnl": strategy_returns.tolist()})
+    benchmark = pl.DataFrame({"date": dates, "pnl": bench_returns.tolist()})
 
-# The metrics DataFrame includes benchmark-relative columns when base_pnl is given
-print("\nAll metrics:")
-print(results["metrics"])
+    results = katsustats.reports.full(pnl, base_pnl=benchmark, show=False)
+
+    # The metrics DataFrame includes benchmark-relative columns when base_pnl is given
+    print("\nAll metrics:")
+    print(results["metrics"])
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,18 @@ classifiers = [
     "Topic :: Office/Business :: Financial :: Investment",
     "Typing :: Typed",
 ]
+keywords = [
+    "backtest",
+    "quant",
+    "quantitative-finance",
+    "polars",
+    "sharpe",
+    "drawdown",
+    "returns",
+    "finance",
+    "trading",
+    "performance-analytics",
+]
 dependencies = [
     "polars>=1.0.0",
     "numpy>=1.24.0",


### PR DESCRIPTION
## Summary

Closes the new-user UX gap identified by comparing katsustats against pybotters:

- **`examples/`** — three self-contained runnable scripts (synthetic data, no setup needed): `quickstart.py`, `with_benchmark.py`, `html_report.py`
- **`CHANGELOG.md`** — Keep a Changelog 1.1.0 format, seeded with v0.1.0 feature list and an `[Unreleased]` header
- **`CONTRIBUTING.md`** — setup, test, and lint instructions; code conventions
- **`.github/ISSUE_TEMPLATE/`** — `bug_report.yml`, `feature_request.yml`, `config.yml` (disables blank issues)
- **`README.md`** — added Python 3.9+, CI status, and Ruff badges
- **`pyproject.toml`** — added `keywords` for PyPI search discoverability

## Test plan

- [ ] `uv run python examples/quickstart.py` — prints metrics tables, no errors
- [ ] `uv run python examples/with_benchmark.py` — prints 22-row metrics table with Alpha/Beta/Correlation rows
- [ ] `uv run python examples/html_report.py` — writes `report.html` (~860 KB) to current directory
- [ ] `uv run ruff check examples/ && uv run ruff format --check examples/` — all checks pass
- [ ] `uv run pytest tests/ -v` — 207 tests pass
- [ ] `uv build` — builds successfully with updated `pyproject.toml`
- [ ] After merge: verify CI badge resolves at `https://github.com/katsu1110/katsustats/actions/workflows/ci.yml`
- [ ] After merge: visit `https://github.com/katsu1110/katsustats/issues/new/choose` — confirm two structured templates appear, blank issues disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)