### PR TITLE
fix: ensure plt.close() is called when show=False

### DIFF
--- a/src/katsustats/reports.py
+++ b/src/katsustats/reports.py
@@ -352,53 +352,44 @@ def full(
     # ── 4. Plots ────────────────────────────────────────────────────
     figures: dict[str, plt.Figure] = {}
 
+    def _handle_fig(name: str, fg: plt.Figure) -> None:
+        figures[name] = fg
+        if show:
+            fg.show()
+        else:
+            plt.close(fg)
+
     # Cumulative Returns
     fig = plots.plot_cumulative_returns(pnl, base_pnl, figsize=figsize_main)
-    figures["cumulative_returns"] = fig
-    if show:
-        fig.show()
+    _handle_fig("cumulative_returns", fig)
 
     # Drawdown
     fig = plots.plot_drawdown(pnl, figsize=figsize_small)
-    figures["drawdown"] = fig
-    if show:
-        fig.show()
+    _handle_fig("drawdown", fig)
 
     # Monthly Heatmap
     fig = plots.plot_monthly_heatmap(pnl, figsize=figsize_main)
-    figures["monthly_heatmap"] = fig
-    if show:
-        fig.show()
+    _handle_fig("monthly_heatmap", fig)
 
     # Yearly Returns
     fig = plots.plot_yearly_returns(pnl, base_pnl, figsize=figsize_main)
-    figures["yearly_returns"] = fig
-    if show:
-        fig.show()
+    _handle_fig("yearly_returns", fig)
 
     # Return Distribution
     fig = plots.plot_return_distribution(pnl, base_pnl, figsize=figsize_main)
-    figures["distribution"] = fig
-    if show:
-        fig.show()
+    _handle_fig("distribution", fig)
 
     # Rolling Sharpe
     fig = plots.plot_rolling_sharpe(pnl, base_pnl, figsize=figsize_small)
-    figures["rolling_sharpe"] = fig
-    if show:
-        fig.show()
+    _handle_fig("rolling_sharpe", fig)
 
     # Rolling Volatility
     fig = plots.plot_rolling_volatility(pnl, base_pnl, figsize=figsize_small)
-    figures["rolling_volatility"] = fig
-    if show:
-        fig.show()
+    _handle_fig("rolling_volatility", fig)
 
     # Day-of-Week Analysis
     fig = plots.plot_dow_returns(pnl)
-    figures["dow_returns"] = fig
-    if show:
-        fig.show()
+    _handle_fig("dow_returns", fig)
 
     return {
         "summary": summary,


### PR DESCRIPTION
Re-applying the fix via a PR. This closes plots when show=False to avoid auto-showing in notebooks.