### PR TITLE
fix: format stdout tables, fix drawdown date dtype, fix pct axis precision, unify DoW chart palette

### DIFF
--- a/src/katsustats/plots.py
+++ b/src/katsustats/plots.py
@@ -34,8 +34,6 @@ _COLORS = {
     "bg": "#FAFAFA",
 }
 
-_DOW_COLORS = ["#E53935", "#FB8C00", "#FDD835", "#43A047", "#1E88E5"]  # Mon-Fri
-
 _HEATMAP_CMAP = LinearSegmentedColormap.from_list(
     "katsustats_diverging",
     [_COLORS["negative"], "#ffffff", _COLORS["positive"]],
@@ -64,7 +62,12 @@ def _add_title(ax, fig, title: str, subtitle: str = ""):
 
 
 def _pct_formatter(x, _):
-    return f"{x:.0%}" if abs(x) < 1 else f"{x:.1%}"
+    a = abs(x)
+    if a >= 0.1:
+        return f"{x:.0%}"
+    if a >= 0.01:
+        return f"{x:.1%}"
+    return f"{x:.2%}"
 
 
 def _align_to_common_dates(
@@ -711,7 +714,7 @@ def plot_dow_returns(df: DataFrameLike, figsize: tuple = (10, 5)) -> Figure:
     bars2 = ax2.bar(
         names,
         wr,
-        color=_DOW_COLORS[: len(names)],
+        color=_COLORS["strategy"],
         alpha=0.85,
         edgecolor="white",
         linewidth=0.5,

--- a/src/katsustats/reports.py
+++ b/src/katsustats/reports.py
@@ -9,6 +9,7 @@ Primary entry points:
 from __future__ import annotations
 
 import base64
+import datetime as _dt
 import io
 import math
 
@@ -34,7 +35,7 @@ def _print_df(df: pl.DataFrame, title: str = "") -> None:
     for col in cols:
         max_w = len(col)
         for val in data[col]:
-            max_w = max(max_w, len(str(val)) if val is not None else 4)
+            max_w = max(max_w, len(_format_cell(col, val)))
         widths[col] = max_w + 2
 
     # Header
@@ -46,8 +47,7 @@ def _print_df(df: pl.DataFrame, title: str = "") -> None:
     n_rows = len(data[cols[0]])
     for i in range(n_rows):
         row = "  ".join(
-            str(data[col][i] if data[col][i] is not None else "—").rjust(widths[col])
-            for col in cols
+            _format_cell(col, data[col][i]).rjust(widths[col]) for col in cols
         )
         print(row)
     print()
@@ -87,6 +87,8 @@ def _format_cell(col: str, val: object) -> str:
         return "—"
     if isinstance(val, float) and math.isnan(val):
         return "—"
+    if isinstance(val, (_dt.datetime, _dt.date)):
+        return val.isoformat()[:10]
     if col in _PCT_COLS:
         return f"{val:.2%}"
     if col in _INT_COLS:

--- a/src/katsustats/stats.py
+++ b/src/katsustats/stats.py
@@ -390,9 +390,9 @@ def drawdown_details(df: DataFrameLike, top_n: int = 5) -> pl.DataFrame:
             recovery_idx = i if i < n else None
             periods.append(
                 {
-                    "start": dates_np[start_idx],
-                    "trough": dates_np[trough_idx],
-                    "recovery": dates_np[recovery_idx]
+                    "start": dates_np[start_idx].item(),
+                    "trough": dates_np[trough_idx].item(),
+                    "recovery": dates_np[recovery_idx].item()
                     if recovery_idx is not None
                     else None,
                     "max_dd": min_dd,
@@ -417,7 +417,16 @@ def drawdown_details(df: DataFrameLike, top_n: int = 5) -> pl.DataFrame:
             }
         )
 
-    result = pl.DataFrame(periods)
+    result = pl.DataFrame(
+        {
+            "start": pl.Series([p["start"] for p in periods], dtype=pl.Date),
+            "trough": pl.Series([p["trough"] for p in periods], dtype=pl.Date),
+            "recovery": pl.Series([p["recovery"] for p in periods], dtype=pl.Date),
+            "max_dd": [p["max_dd"] for p in periods],
+            "drawdown_days": [p["drawdown_days"] for p in periods],
+            "recovery_days": [p["recovery_days"] for p in periods],
+        }
+    )
     result = result.sort("max_dd").head(top_n)
     return result
 

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -101,6 +101,19 @@ class TestFull:
         captured = capsys.readouterr()
         assert len(captured.out) > 0
 
+    def test_stdout_no_raw_floats_in_drawdown_table(self, sample_df, capsys):
+        reports.full(sample_df, show=False, verbose=True)
+        out = capsys.readouterr().out
+        # raw nanosecond timestamps (1.7e18) or unformatted floats must not appear
+        assert "e+" not in out
+        assert "e-" not in out
+
+    def test_stdout_pct_columns_formatted_in_dow_table(self, sample_df, capsys):
+        reports.full(sample_df, show=False, verbose=True)
+        out = capsys.readouterr().out
+        # Day-of-Week section must contain formatted percentages
+        assert "%" in out
+
 
 # ---------------------------------------------------------------------------
 # reports.html

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -344,6 +344,13 @@ class TestDrawdownDetails:
             vals = dd.get_column("recovery_days").to_list()
             assert all(v is None or v >= 0 for v in vals)
 
+    def test_date_columns_are_date_dtype(self, sample_df):
+        dd = stats.drawdown_details(sample_df)
+        if dd.height > 0:
+            assert dd.schema["start"] == pl.Date
+            assert dd.schema["trough"] == pl.Date
+            assert dd.schema["recovery"] == pl.Date
+
 
 class TestDayOfWeekStats:
     def test_returns_dataframe(self, sample_df):


### PR DESCRIPTION
## Summary

- **Stdout tables now formatted**: `_print_df` routes all cells through `_format_cell`, so `Top 5 Drawdowns` and `Day-of-Week Statistics` print clean dates (`2022-01-04`) and percentages (`-45.86%`) instead of raw floats / nanosecond integers
- **Drawdown date dtype fixed**: `drawdown_details` stored `numpy.datetime64` values directly in the period dict, causing `pl.DataFrame` to infer `Object` type. Fixed by calling `.item()` to get Python `datetime.date` objects and building the result with explicit `pl.Series(dtype=pl.Date)`
- **`_pct_formatter` branches were inverted**: small values like `0.001` rendered as `"0%"` because the `.0%` branch triggered for `abs(x) < 1`. Now magnitude-aware: `≥10%` → 0dp, `1–10%` → 1dp, `<1%` → 2dp — Mean-Return-by-Day y-axis now shows useful precision
- **Win-Rate-by-Day bars drop the rainbow palette**: `_DOW_COLORS` replaced with `_COLORS["strategy"]` (Material Blue) to match every other chart in the report; unused `_DOW_COLORS` constant removed

**Color theme note**: the existing `_COLORS` Material palette (blue/orange/green/red) is already professional and consistent across all plots. The only inconsistency was `_DOW_COLORS`, which this PR removes. No wholesale palette change needed.

## Test plan

- [ ] `uv run pytest tests/ -v` — all 231 tests pass
- [ ] `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/` — clean
- [ ] Smoke-test stdout: `Top 5 Drawdowns` prints `YYYY-MM-DD` dates and `max_dd` as `%`; `Day-of-Week Statistics` prints mean return and win rate as `%`
- [ ] `Mean Return by Day` y-axis shows non-zero percentages (e.g. `0.10%`)
- [ ] `Win Rate by Day` bars are all solid strategy-blue (no rainbow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)