### PR TITLE
Accept datetime date columns in dataframe inputs

### DIFF
--- a/src/katsustats/_dataframe.py
+++ b/src/katsustats/_dataframe.py
@@ -18,6 +18,9 @@ def ensure_polars(df: Any, name: str = "df") -> pl.DataFrame:
     """Convert a pandas or Polars DataFrame to a Polars DataFrame.
 
     Validates that the result has the required ["date", "pnl"] columns.
+    If the ``date`` column is not already ``pl.Date`` (e.g. it is a
+    ``pl.Datetime``), it is cast to ``pl.Date``, truncating any time
+    component.
     """
     if isinstance(df, pl.DataFrame):
         polars_df = df

--- a/src/katsustats/_dataframe.py
+++ b/src/katsustats/_dataframe.py
@@ -32,4 +32,6 @@ def ensure_polars(df: Any, name: str = "df") -> pl.DataFrame:
         )
     missing = {"date", "pnl"} - set(polars_df.columns)
     assert not missing, f"{name} is missing columns: {missing}"
+    if polars_df.schema["date"] != pl.Date:
+        polars_df = polars_df.with_columns(pl.col("date").cast(pl.Date))
     return polars_df

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -91,6 +91,11 @@ class TestFull:
         )
         assert isinstance(result["metrics"], pl.DataFrame)
 
+    def test_datetime_date_column_accepted(self, sample_df):
+        dt_df = sample_df.with_columns(pl.col("date").cast(pl.Datetime))
+        result = reports.full(dt_df, show=False, verbose=False)
+        assert isinstance(result["drawdowns"], pl.DataFrame)
+
     def test_verbose_false_suppresses_stdout(self, sample_df, capsys):
         reports.full(sample_df, show=False, verbose=False)
         captured = capsys.readouterr()

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -351,6 +351,16 @@ class TestDrawdownDetails:
             assert dd.schema["trough"] == pl.Date
             assert dd.schema["recovery"] == pl.Date
 
+    def test_datetime_date_column_accepted(self, sample_df):
+        dt_df = sample_df.with_columns(pl.col("date").cast(pl.Datetime))
+        dd = stats.drawdown_details(dt_df)
+        assert isinstance(dd, pl.DataFrame)
+        if dd.height > 0:
+            assert dd.schema["start"] == pl.Date
+            assert dd.schema["trough"] == pl.Date
+            assert dd.schema["recovery"] == pl.Date
+        assert dd.height == stats.drawdown_details(sample_df).height
+
 
 class TestDayOfWeekStats:
     def test_returns_dataframe(self, sample_df):


### PR DESCRIPTION
## Summary
- cast incoming `date` columns to `pl.Date` during dataframe normalization
- allow report and drawdown paths to accept datetime-backed inputs
- add regression coverage for datetime `date` columns in reports and stats

## Testing
- /Users/katsuhisa/myprojects/katsustats/.venv/bin/python -m pytest tests/ -v
- /Users/katsuhisa/myprojects/katsustats/.venv/bin/python -m ruff check src tests