### PR TITLE
Add GitHub Copilot skills for publishing and skill scaffolding

### DIFF
--- a/.github/skills/make-skill-template/SKILL.md
+++ b/.github/skills/make-skill-template/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: 'make-skill-template'
+description: 'Create new GitHub Copilot agent skills for this repository. Use when asked to create a skill, scaffold a new skill, add a reusable agent workflow, or define SKILL.md frontmatter, structure, and optional bundled resources.'
+license: 'Apache-2.0'
+---
+
+# Make Skill Template
+
+Create a new agent skill for this repository.
+
+Use this skill when a user wants a reusable Copilot workflow packaged as a skill folder with a `SKILL.md` file and, if needed, bundled supporting files.
+
+## When to Use This Skill
+
+Use this skill when:
+- The user asks to create or scaffold a new skill
+- The user wants a reusable workflow for GitHub Copilot
+- A task would benefit from a dedicated slash-command style skill
+- The user needs help structuring `SKILL.md` frontmatter and instructions
+
+## Skill Structure Rules
+
+Create project skills under `.github/skills/<skill-name>/`.
+
+Each skill must have:
+- A lowercase, hyphenated folder name
+- A `SKILL.md` file
+- A `name` field that matches the folder name exactly
+- A `description` field that explains both WHAT the skill does and WHEN it should be used
+
+Optional subfolders may be added when useful:
+- `references/` for longer documentation
+- `templates/` for starter content the agent can adapt
+- `assets/` for static files used as-is
+- `scripts/` for helper automation
+
+## Step-by-Step Workflow
+
+### 1. Define the skill scope
+
+Identify:
+- The single main purpose of the skill
+- The user triggers and keywords that should activate it
+- Any repository-specific constraints or conventions
+- Whether supporting files are needed
+
+Prefer one focused purpose per skill.
+
+### 2. Choose the skill name
+
+The skill name must:
+- be lowercase
+- use hyphens instead of spaces
+- be short, descriptive, and action-oriented
+- match the folder name exactly
+
+Good examples:
+- `publish`
+- `make-skill-template`
+- `generate-report`
+
+Avoid vague names like:
+- `helper`
+- `tools`
+- `misc`
+
+### 3. Create `SKILL.md`
+
+Use this structure:
+
+```markdown
+---
+name: 'skill-name'
+description: 'What this skill does. Use when the user asks for X, Y, or Z, or when the task involves A and B.'
+license: 'Apache-2.0'
+---
+
+# Skill Title
+
+One short paragraph describing the skill.
+
+## When to Use This Skill
+
+- Trigger 1
+- Trigger 2
+- Trigger 3
+
+## Requirements
+
+- Important constraint 1
+- Important constraint 2
+
+## Step-by-Step Workflow
+
+### 1. First step
+
+What to do.
+
+### 2. Second step
+
+What to do.
+
+## Gotchas
+
+- Common mistake 1
+- Common mistake 2
+
+## References
+
+- `references/example.md`
+```
+
+### 4. Write a strong description
+
+The `description` is the main discovery signal.
+
+It should include:
+1. What the skill does
+2. When to use it
+3. Likely trigger words the user may say
+
+Good description pattern:
+- `Create release notes for this repository. Use when asked to summarize commits, prepare changelog text, or draft GitHub release notes.`
+
+Weak description pattern:
+- `Release helper.`
+
+## Requirements
+
+When creating a new skill:
+- Keep instructions specific and actionable
+- Prefer repository-specific guidance over generic advice
+- Keep the skill focused on one repeatable workflow
+- Keep changes minimal when scaffolding files
+- Reference bundled files with relative paths if they exist
+- Do not add optional directories unless they provide real value
+
+## Gotchas
+
+- Do not let the `name` differ from the folder name
+- Do not use a vague `description`; weak discovery makes the skill hard to trigger
+- Do not duplicate long reference content in `SKILL.md`; place it in `references/` instead
+- Do not create oversized or unnecessary bundled assets
+- Do not make the skill task-specific if it should be reusable
+
+## Validation Checklist
+
+Before finishing, confirm that:
+- Folder name is lowercase and hyphenated
+- `SKILL.md` exists in the skill folder
+- `name` matches the folder name exactly
+- `description` clearly explains WHAT and WHEN
+- Body instructions are concise and reusable
+- Any referenced bundled files actually exist
+
+## Example Output
+
+For a skill named `draft-changelog`, the result should look like:
+
+```text
+.github/skills/draft-changelog/
+└── SKILL.md
+```
+
+With frontmatter like:
+
+```yaml
+name: 'draft-changelog'
+description: 'Draft changelog entries for this repository. Use when asked to summarize recent changes, prepare release notes, or group commits into user-facing sections.'
+```
+
+## References
+
+- Agent skills in this repository live under `.github/skills/`
+- Use existing skills in this repository as style references when relevant

--- a/.github/skills/publish/SKILL.md
+++ b/.github/skills/publish/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: publish
+description: Publish a new katsustats release to PyPI. Use this when asked to cut a release, bump the package version, create GitHub release notes, or publish katsustats to PyPI.
+license: Apache-2.0
+---
+
+# Publish katsustats to PyPI
+
+Use this skill when the user wants to publish a new katsustats release.
+
+This repository is a Python package named `katsustats`.
+
+Important repository facts:
+- The package version is defined in `src/katsustats/__init__.py` as `__version__`.
+- `pyproject.toml` uses dynamic versioning via `[tool.hatch.version] path = "src/katsustats/__init__.py"`.
+- The release workflow is defined in `.github/workflows/publish.yml`.
+- Publishing to PyPI happens automatically when a GitHub release is published.
+- The workflow builds with `uv build` and publishes with trusted publishing.
+- The default branch is `main`.
+
+Follow this process exactly.
+
+## 1. Determine the new version
+
+1. Read the current version from `src/katsustats/__init__.py`.
+2. If the user explicitly provided a version, use it.
+3. Otherwise, inspect commits since the latest release tag and choose the bump level:
+   - **patch** (`x.y.Z`): bug fixes only, internal cleanups, no new public API.
+   - **minor** (`x.Y.0`): new public functions, new features, backward-compatible enhancements.
+   - **major** (`X.0.0`): breaking public API changes.
+4. Base the rationale on actual commits, not assumptions.
+5. If there is no prior tag, compare against the full history and explain that no previous release tag exists.
+
+## 2. Confirm before making changes
+
+Before editing files, committing, pushing, or creating a release:
+- State the current version, proposed new version, and bump rationale in one sentence.
+- Ask the user to confirm.
+- Stop and wait for confirmation.
+
+Never perform the publish steps without explicit confirmation.
+
+## 3. Bump the version
+
+After confirmation:
+1. Update `src/katsustats/__init__.py` so `__version__` matches the new version.
+2. Keep the change minimal.
+
+## 4. Commit and push
+
+After the version bump:
+1. Stage `src/katsustats/__init__.py`.
+2. Commit with this exact message:
+   - `chore: bump version to <new_version>`
+3. Push to `origin main`.
+
+Before committing, check whether the working tree contains unrelated changes. If it does, warn the user and avoid including unrelated files unless they explicitly ask for that.
+
+## 5. Build release notes
+
+1. Find the latest release tag.
+2. Collect commits since that tag.
+3. Exclude the version-bump commit from the release notes.
+4. Group the notes into concise sections such as:
+   - Features
+   - Fixes
+   - Docs
+   - Maintenance
+5. Keep the notes short and user-facing.
+6. If there are no commits in a section, omit that section.
+
+## 6. Create the GitHub release
+
+Create a GitHub release with:
+- Tag: `v<new_version>`
+- Title: `v<new_version>`
+- Target: `main`
+- Notes: the release notes you prepared
+
+This release triggers `.github/workflows/publish.yml`, which builds and uploads the package to PyPI.
+
+## 7. Finish clearly
+
+After the release is created:
+- Return the GitHub release URL.
+- Remind the user to watch the Actions tab and confirm the publish workflow succeeds.
+- If release creation fails, report the failure briefly and include the next actionable step.
+
+## Operational guidance
+
+- Prefer reading the repository state directly instead of guessing.
+- Use git tags and commit history to justify the version bump.
+- Do not include the version-bump commit itself in the release notes.
+- Do not change any files other than the version file unless the user asks.
+- Keep responses short and action-oriented.
+
+## Example prompts
+
+- `Use the /publish skill to cut the next PyPI release for katsustats.`
+- `Use the /publish skill and release version 0.3.0.`
+- `Publish katsustats to PyPI.`


### PR DESCRIPTION
## Summary
- add a `publish` Copilot skill for the PyPI release workflow
- add a `make-skill-template` Copilot skill for scaffolding repository skills
- keep both skills under `.github/skills/` for project-local discovery

## Testing
- not run (documentation/skill files only)
