### PR TITLE
Fix drawdown datetime handling

### DIFF
--- a/src/katsustats/stats.py
+++ b/src/katsustats/stats.py
@@ -376,14 +376,13 @@ def drawdown_details(df: DataFrameLike, top_n: int = 5) -> pl.DataFrame:
     """
     df = ensure_polars(df)
     r = _to_returns(df)
-    dates = df.get_column("date")
+    dates = df.get_column("date").to_list()
     cumval = _cumulative_value(r)
     running_max = cumval.cum_max()
     dd = (cumval - running_max) / running_max
 
     # Identify drawdown periods (contiguous blocks where dd < 0)
     dd_np = dd.to_numpy()
-    dates_np = dates.to_numpy()
     n = len(dd_np)
 
     periods: list[dict] = []
@@ -401,9 +400,9 @@ def drawdown_details(df: DataFrameLike, top_n: int = 5) -> pl.DataFrame:
             recovery_idx = i if i < n else None
             periods.append(
                 {
-                    "start": dates_np[start_idx].item(),
-                    "trough": dates_np[trough_idx].item(),
-                    "recovery": dates_np[recovery_idx].item()
+                    "start": dates[start_idx],
+                    "trough": dates[trough_idx],
+                    "recovery": dates[recovery_idx]
                     if recovery_idx is not None
                     else None,
                     "max_dd": min_dd,

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -96,6 +96,20 @@ class TestFull:
         result = reports.full(dt_df, show=False, verbose=False)
         assert isinstance(result["drawdowns"], pl.DataFrame)
 
+    def test_pandas_datetime_date_column_accepted(self):
+        from datetime import datetime, timedelta
+
+        import pandas as pd
+
+        start = datetime(2024, 1, 1)
+        dates = [start + timedelta(days=i) for i in range(20)]
+        pnl = [0.01, -0.005, 0.008, -0.012, 0.003] * 4
+        df = pd.DataFrame({"date": dates, "pnl": pnl})
+
+        result = reports.full(df, show=False, verbose=False)
+
+        assert isinstance(result["drawdowns"], pl.DataFrame)
+
     def test_verbose_false_suppresses_stdout(self, sample_df, capsys):
         reports.full(sample_df, show=False, verbose=False)
         captured = capsys.readouterr()

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -361,6 +361,24 @@ class TestDrawdownDetails:
             assert dd.schema["recovery"] == pl.Date
         assert dd.height == stats.drawdown_details(sample_df).height
 
+    def test_pandas_datetime_date_column_accepted(self):
+        from datetime import datetime, timedelta
+
+        import pandas as pd
+
+        start = datetime(2024, 1, 1)
+        dates = [start + timedelta(days=i) for i in range(8)]
+        pnl = [0.02, -0.01, -0.03, 0.01, 0.005, -0.02, 0.01, 0.015]
+        df = pd.DataFrame({"date": dates, "pnl": pnl})
+
+        dd = stats.drawdown_details(df)
+
+        assert isinstance(dd, pl.DataFrame)
+        if dd.height > 0:
+            assert dd.schema["start"] == pl.Date
+            assert dd.schema["trough"] == pl.Date
+            assert dd.schema["recovery"] == pl.Date
+
 
 class TestDayOfWeekStats:
     def test_returns_dataframe(self, sample_df):


### PR DESCRIPTION
## Summary
- avoid NumPy scalar conversion when building drawdown date columns
- preserve normalized date values directly from the Polars `date` column
- add regression coverage for pandas datetime inputs in stats and reports

## Testing
- uv run ruff check src/ tests/
- uv run pytest tests/ -q