### PR TITLE
Compound duplicate-date returns with warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ with two required columns:
 When a pandas DataFrame is passed, `katsustats` converts it to Polars at the
 start of processing.
 
+If multiple rows share the same `date`, `katsustats` compounds those same-day
+`pnl` values into one daily return, emits a warning, and continues.
+
 ## Basic usage
 
 ```python

--- a/src/katsustats/_dataframe.py
+++ b/src/katsustats/_dataframe.py
@@ -47,11 +47,10 @@ def _compound_duplicate_dates(df: pl.DataFrame, name: str) -> pl.DataFrame:
 def ensure_polars(df: Any, name: str = "df") -> pl.DataFrame:
     """Convert a pandas or Polars DataFrame to a Polars DataFrame.
 
-    Validates that the result has the required ["date", "pnl"] columns.
-    If the ``date`` column is not already ``pl.Date`` (e.g. it is a
-    ``pl.Datetime``), it is cast to ``pl.Date``, truncating any time
-    component. If duplicate dates are present after normalization, same-date
-    ``pnl`` rows are compounded into one daily return and a warning is emitted.
+    Always returns a DataFrame with exactly the columns ``["date", "pnl"]``.
+    Validates that the input has those columns, casts ``date`` to ``pl.Date``
+    if needed, and compounds same-date ``pnl`` rows into one daily return with
+    a warning when duplicate dates are detected.
     """
     if isinstance(df, pl.DataFrame):
         polars_df = df
@@ -68,4 +67,5 @@ def ensure_polars(df: Any, name: str = "df") -> pl.DataFrame:
     assert not missing, f"{name} is missing columns: {missing}"
     if polars_df.schema["date"] != pl.Date:
         polars_df = polars_df.with_columns(pl.col("date").cast(pl.Date))
+    polars_df = polars_df.select(["date", "pnl"])
     return _compound_duplicate_dates(polars_df, name)

--- a/src/katsustats/_dataframe.py
+++ b/src/katsustats/_dataframe.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from typing import Any, Protocol, runtime_checkable
 
 import polars as pl
@@ -14,13 +15,34 @@ def _is_pandas_dataframe(obj: Any) -> bool:
     return type(obj).__module__.startswith("pandas")
 
 
+def _compound_duplicate_dates(df: pl.DataFrame, name: str) -> pl.DataFrame:
+    """Compound duplicate same-date returns into one daily return per date."""
+    if df.height == 0 or df.get_column("date").n_unique() == df.height:
+        return df
+
+    warnings.warn(
+        (
+            f"{name} has duplicate dates; compounding same-date pnl values into "
+            "one daily return per date."
+        ),
+        UserWarning,
+        stacklevel=3,
+    )
+    return (
+        df.group_by("date")
+        .agg(((pl.col("pnl") + 1).product() - 1).alias("pnl"))
+        .sort("date")
+    )
+
+
 def ensure_polars(df: Any, name: str = "df") -> pl.DataFrame:
     """Convert a pandas or Polars DataFrame to a Polars DataFrame.
 
     Validates that the result has the required ["date", "pnl"] columns.
     If the ``date`` column is not already ``pl.Date`` (e.g. it is a
     ``pl.Datetime``), it is cast to ``pl.Date``, truncating any time
-    component.
+    component. If duplicate dates are present after normalization, same-date
+    ``pnl`` rows are compounded into one daily return and a warning is emitted.
     """
     if isinstance(df, pl.DataFrame):
         polars_df = df
@@ -37,4 +59,4 @@ def ensure_polars(df: Any, name: str = "df") -> pl.DataFrame:
     assert not missing, f"{name} is missing columns: {missing}"
     if polars_df.schema["date"] != pl.Date:
         polars_df = polars_df.with_columns(pl.col("date").cast(pl.Date))
-    return polars_df
+    return _compound_duplicate_dates(polars_df, name)

--- a/src/katsustats/_dataframe.py
+++ b/src/katsustats/_dataframe.py
@@ -15,6 +15,19 @@ def _is_pandas_dataframe(obj: Any) -> bool:
     return type(obj).__module__.startswith("pandas")
 
 
+def _compound_by_date(df: pl.DataFrame) -> pl.DataFrame:
+    """Compound all rows with the same date into one daily return per date.
+
+    This is the core compounding helper shared by duplicate-date normalization
+    (``_compound_duplicate_dates``) and ``stats._daily_returns``.
+    """
+    return (
+        df.group_by("date")
+        .agg(((pl.col("pnl") + 1).product() - 1).alias("pnl"))
+        .sort("date")
+    )
+
+
 def _compound_duplicate_dates(df: pl.DataFrame, name: str) -> pl.DataFrame:
     """Compound duplicate same-date returns into one daily return per date."""
     if df.height == 0 or df.get_column("date").n_unique() == df.height:
@@ -28,11 +41,7 @@ def _compound_duplicate_dates(df: pl.DataFrame, name: str) -> pl.DataFrame:
         UserWarning,
         stacklevel=3,
     )
-    return (
-        df.group_by("date")
-        .agg(((pl.col("pnl") + 1).product() - 1).alias("pnl"))
-        .sort("date")
-    )
+    return _compound_by_date(df)
 
 
 def ensure_polars(df: Any, name: str = "df") -> pl.DataFrame:

--- a/src/katsustats/stats.py
+++ b/src/katsustats/stats.py
@@ -281,7 +281,8 @@ def _period_returns(df: pl.DataFrame, every: str) -> pl.Series:
 
 def _daily_returns(df: pl.DataFrame) -> pl.DataFrame:
     """Compound returns to one row per calendar date."""
-    return _compound_by_date(df.with_columns(pl.col("date").cast(pl.Date)).sort("date"))
+    normalised = df.with_columns(pl.col("date").cast(pl.Date)).sort("date")
+    return _compound_by_date(normalised)
 
 
 def consecutive_wins(df: DataFrameLike) -> int:

--- a/src/katsustats/stats.py
+++ b/src/katsustats/stats.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import numpy as np
 import polars as pl
 
-from ._dataframe import DataFrameLike, ensure_polars
+from ._dataframe import DataFrameLike, _compound_by_date, ensure_polars
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -281,13 +281,7 @@ def _period_returns(df: pl.DataFrame, every: str) -> pl.Series:
 
 def _daily_returns(df: pl.DataFrame) -> pl.DataFrame:
     """Compound returns to one row per calendar date."""
-    return (
-        df.with_columns(pl.col("date").cast(pl.Date))
-        .sort("date")
-        .group_by("date")
-        .agg(((pl.col("pnl") + 1).product() - 1).alias("pnl"))
-        .sort("date")
-    )
+    return _compound_by_date(df.with_columns(pl.col("date").cast(pl.Date)).sort("date"))
 
 
 def consecutive_wins(df: DataFrameLike) -> int:

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -81,9 +81,11 @@ class TestFull:
         result = reports.full(sample_df, None, 0.04, show=False)
         assert isinstance(result["metrics"], pl.DataFrame)
 
-    def test_duplicate_dates_raises(self, grouped_sample_pandas_df):
-        with pytest.raises(AssertionError):
-            reports.full(grouped_sample_pandas_df, show=False)
+    def test_duplicate_dates_warns_and_aggregates(self, grouped_sample_pandas_df):
+        with pytest.warns(UserWarning, match="duplicate dates"):
+            result = reports.full(grouped_sample_pandas_df, show=False)
+        assert isinstance(result["metrics"], pl.DataFrame)
+        assert isinstance(result["drawdowns"], pl.DataFrame)
 
     def test_accepts_pandas_inputs(self, sample_pandas_df, benchmark_pandas_df):
         result = reports.full(
@@ -223,6 +225,7 @@ class TestHtml:
         result = reports.html(sample_df, None, 0.04)
         assert isinstance(result, str)
 
-    def test_duplicate_dates_raises(self, grouped_sample_pandas_df):
-        with pytest.raises(AssertionError):
-            reports.html(grouped_sample_pandas_df)
+    def test_duplicate_dates_warns_and_aggregates(self, grouped_sample_pandas_df):
+        with pytest.warns(UserWarning, match="duplicate dates"):
+            result = reports.html(grouped_sample_pandas_df)
+        assert isinstance(result, str)

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -81,11 +81,22 @@ class TestFull:
         result = reports.full(sample_df, None, 0.04, show=False)
         assert isinstance(result["metrics"], pl.DataFrame)
 
-    def test_duplicate_dates_warns_and_aggregates(self, grouped_sample_pandas_df):
+    def test_duplicate_dates_warns_and_aggregates(self):
+        duplicate_dates_df = pl.DataFrame(
+            {
+                "date": ["2023-01-02", "2023-01-02", "2023-01-03"],
+                "pnl": [0.10, 0.20, -0.10],
+            }
+        ).with_columns(pl.col("date").cast(pl.Date))
+
+        # 2023-01-02 => (1.10 * 1.20) - 1 = 0.32
+        # across dates  => (1.32 * 0.90) - 1 = 0.188
+        expected_total_return = (1.10 * 1.20) * 0.90 - 1.0
+
         with pytest.warns(UserWarning, match="duplicate dates"):
-            result = reports.full(grouped_sample_pandas_df, show=False)
-        assert isinstance(result["metrics"], pl.DataFrame)
-        assert isinstance(result["drawdowns"], pl.DataFrame)
+            result = reports.full(duplicate_dates_df, show=False)
+
+        assert result["summary"]["total_return"] == pytest.approx(expected_total_return)
 
     def test_accepts_pandas_inputs(self, sample_pandas_df, benchmark_pandas_df):
         result = reports.full(
@@ -225,7 +236,21 @@ class TestHtml:
         result = reports.html(sample_df, None, 0.04)
         assert isinstance(result, str)
 
-    def test_duplicate_dates_warns_and_aggregates(self, grouped_sample_pandas_df):
+    def test_duplicate_dates_warns_and_aggregates(self):
+        duplicate_dates_df = pl.DataFrame(
+            {
+                "date": ["2023-01-02", "2023-01-02", "2023-01-03"],
+                "pnl": [0.10, 0.20, -0.10],
+            }
+        ).with_columns(pl.col("date").cast(pl.Date))
+
         with pytest.warns(UserWarning, match="duplicate dates"):
-            result = reports.html(grouped_sample_pandas_df)
+            result = reports.html(duplicate_dates_df)
+
+        # HTML should reflect the compounded series (2 rows, not 3)
         assert isinstance(result, str)
+        assert result == reports.html(
+            pl.DataFrame(
+                {"date": ["2023-01-02", "2023-01-03"], "pnl": [0.32, -0.10]}
+            ).with_columns(pl.col("date").cast(pl.Date))
+        )

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -36,6 +36,20 @@ class TestTotalReturn:
         result = stats.total_return(df)
         assert abs(result - (-0.01)) < 1e-10
 
+    def test_duplicate_dates_warns_and_compounds_same_day_returns(self):
+        df = pl.DataFrame(
+            {
+                "date": ["2023-01-02", "2023-01-02", "2023-01-03"],
+                "pnl": [0.10, -0.05, 0.02],
+            }
+        ).with_columns(pl.col("date").cast(pl.Date))
+
+        with pytest.warns(UserWarning, match="duplicate dates"):
+            result = stats.total_return(df)
+
+        expected = (1.10 * 0.95) * 1.02 - 1.0
+        assert abs(result - expected) < 1e-10
+
 
 class TestCagr:
     def test_returns_float(self, sample_df):
@@ -1020,7 +1034,8 @@ class TestPeriodPerformanceRaw:
             }
         )
 
-        raw = stats.period_performance_raw(intraday_df, intraday_base_df)
+        with pytest.warns(UserWarning, match="duplicate dates"):
+            raw = stats.period_performance_raw(intraday_df, intraday_base_df)
         expected = stats.period_performance_raw(daily_df, daily_base_df)
 
         for label in raw:


### PR DESCRIPTION
## Summary
- compound same-date `pnl` rows into one daily return during dataframe normalization
- emit a warning when duplicate dates are detected instead of failing report generation
- add tests and docs covering the new behavior

## Testing
- .venv/bin/python -m pytest tests/