### PR TITLE
Sync README and packaging metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,8 @@ start of processing.
 
 If `date` is datetime-like, it is normalized to `pl.Date` before analysis.
 
-After normalization, each `date` must appear exactly once.
-
-If your input has multiple rows for the same day, pre-aggregate them into a
-single daily return before calling `katsustats`.
+If multiple rows share the same `date`, `katsustats` compounds those same-day
+`pnl` values into one daily return, emits a warning, and continues.
 
 ## Basic usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,11 @@ ignore = ["E501"]
 [tool.hatch.version]
 path = "src/katsustats/__init__.py"
 
+[tool.hatch.build.targets.sdist]
+exclude = [
+    "/img",
+]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/src/katsustats/reports.py
+++ b/src/katsustats/reports.py
@@ -357,7 +357,12 @@ def full(
     # ensure_polars() already compounds duplicate same-date rows with a warning,
     # so this uniqueness check is a defensive sanity check.
     pnl = pnl.sort("date")
-    assert pnl["date"].n_unique() == pnl.height, "pnl must have unique dates"
+    assert pnl["date"].n_unique() == pnl.height, (
+        "pnl dates are expected to be unique after ensure_polars() normalization "
+        "and compounding of duplicate same-date rows; if duplicates still exist, "
+        "this indicates an unexpected post-normalization state or a bug. "
+        "Please report this issue if it persists."
+    )
     if base_pnl is not None:
         base_pnl = base_pnl.sort("date")
 

--- a/src/katsustats/reports.py
+++ b/src/katsustats/reports.py
@@ -353,11 +353,11 @@ def full(
         assert "date" in base_pnl.columns, "base_pnl must have a 'date' column"
         assert "pnl" in base_pnl.columns, "base_pnl must have a 'pnl' column"
 
-    # Sort by date and assert one row per date
+    # Sort by date after normalization.
+    # ensure_polars() already compounds duplicate same-date rows with a warning,
+    # so this uniqueness check is a defensive sanity check.
     pnl = pnl.sort("date")
-    assert pnl["date"].n_unique() == pnl.height, (
-        "pnl must have one row per date; pass pre-aggregated portfolio-level returns"
-    )
+    assert pnl["date"].n_unique() == pnl.height, "pnl must have unique dates"
     if base_pnl is not None:
         base_pnl = base_pnl.sort("date")
 
@@ -471,10 +471,11 @@ def _build_html(
         assert "date" in base_pnl.columns, "base_pnl must have a 'date' column"
         assert "pnl" in base_pnl.columns, "base_pnl must have a 'pnl' column"
 
+    # Sort by date after normalization.
+    # ensure_polars() already compounds duplicate same-date rows with a warning,
+    # so this uniqueness check is a defensive sanity check.
     pnl = pnl.sort("date")
-    assert pnl["date"].n_unique() == pnl.height, (
-        "pnl must have one row per date; pass pre-aggregated portfolio-level returns"
-    )
+    assert pnl["date"].n_unique() == pnl.height, "pnl must have unique dates"
     if base_pnl is not None:
         base_pnl = base_pnl.sort("date")
 

--- a/src/katsustats/reports.py
+++ b/src/katsustats/reports.py
@@ -480,7 +480,12 @@ def _build_html(
     # ensure_polars() already compounds duplicate same-date rows with a warning,
     # so this uniqueness check is a defensive sanity check.
     pnl = pnl.sort("date")
-    assert pnl["date"].n_unique() == pnl.height, "pnl must have unique dates"
+    assert pnl["date"].n_unique() == pnl.height, (
+        "Expected `pnl` to have unique dates after `ensure_polars()` "
+        "normalization/compounding. If this fails, check the input for "
+        "duplicate same-date rows or investigate whether normalization "
+        "did not run as expected."
+    )
     if base_pnl is not None:
         base_pnl = base_pnl.sort("date")
 


### PR DESCRIPTION
## Summary
- update the README to match duplicate-date compounding behavior
- clarify duplicate-date handling comments and messages in reports
- exclude the repository `img/` folder from source distributions

## Validation
- built the package with `uv build`
- confirmed `img/` is excluded from the sdist and not present in the wheel