### PR TITLE
feat: add daily return bars to cumulative returns chart

### DIFF
--- a/src/katsustats/plots.py
+++ b/src/katsustats/plots.py
@@ -103,9 +103,9 @@ def _align_to_common_dates(
 def plot_cumulative_returns(
     df: DataFrameLike,
     base_df: DataFrameLike | None = None,
-    figsize: tuple = (12, 5),
+    figsize: tuple = (12, 7),
 ) -> Figure:
-    """Cumulative return curve for strategy vs benchmark."""
+    """Cumulative return curve (top) with daily return bars (bottom)."""
     df = ensure_polars(df)
     if base_df is not None:
         base_df = ensure_polars(base_df, name="base_df")
@@ -113,9 +113,13 @@ def plot_cumulative_returns(
     r = stats._to_returns(df)
     cumval = stats._cumulative(r)
     dates = df.get_column("date").to_numpy()
+    r_np = r.to_numpy()
 
-    fig, ax = plt.subplots(figsize=figsize)
+    fig, (ax, ax_bar) = plt.subplots(
+        2, 1, figsize=figsize, sharex=True, height_ratios=[3, 1]
+    )
     _apply_style(ax, fig)
+    _apply_style(ax_bar, fig)
 
     ax.plot(
         dates, cumval.to_numpy(), lw=1.8, color=_COLORS["strategy"], label="Strategy"
@@ -136,6 +140,13 @@ def plot_cumulative_returns(
     ax.yaxis.set_major_formatter(mticker.FuncFormatter(_pct_formatter))
     ax.axhline(0, color=_COLORS["neutral"], lw=0.8, ls="--")
     ax.legend(fontsize=9, frameon=False)
+
+    bar_colors = [_COLORS["positive"] if v >= 0 else _COLORS["negative"] for v in r_np]
+    ax_bar.bar(dates, r_np, color=bar_colors, alpha=0.7, width=0.8)
+    ax_bar.axhline(0, color=_COLORS["neutral"], lw=0.8, ls="--")
+    ax_bar.yaxis.set_major_formatter(mticker.FuncFormatter(_pct_formatter))
+    ax_bar.set_ylabel("Daily Return", fontsize=8, color=_COLORS["text_secondary"])
+
     _add_title(ax, fig, "Cumulative Returns")
     fig.autofmt_xdate()
     fig.tight_layout()

--- a/src/katsustats/reports.py
+++ b/src/katsustats/reports.py
@@ -353,7 +353,7 @@ def full(
     benchmark: DataFrameLike | None = None,
     rf: float = 0.0,
     periods: int = 252,
-    figsize_main: tuple = (12, 5),
+    figsize_main: tuple = (12, 7),
     figsize_small: tuple = (12, 4),
     show: bool = True,
     verbose: bool = True,
@@ -558,7 +558,7 @@ def _build_html(
 
     # ── Hero chart: Cumulative Returns (full-width) ─────────────────
     hero_b64 = _fig_to_base64(
-        plots.plot_cumulative_returns(returns, benchmark, figsize=(12, 5))
+        plots.plot_cumulative_returns(returns, benchmark, figsize=(12, 7))
     )
     hero_chart = (
         f'<div class="section">'


### PR DESCRIPTION
## Summary

- Converts `plot_cumulative_returns` from a single-panel line chart into a two-panel figure:
  - **Top (75%)**: cumulative returns line, unchanged behaviour
  - **Bottom (25%)**: daily return bars, green for positive days, red for negative days — sharing the x-axis with the top panel
- Default `figsize` updated `(12, 5)` → `(12, 7)` to accommodate both panels
- `reports.full()` default `figsize_main` and the `html()` hero chart hardcoded size updated to match

## Test plan

- [ ] 240/240 tests pass (`uv run pytest tests/ -v`)
- [ ] Visually confirm the combined chart renders correctly with and without a benchmark

🤖 Generated with [Claude Code](https://claude.com/claude-code)