### PR TITLE
feat: CLI — katsustats report command

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,57 @@
+name: Build CLI binaries
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact_name: katsustats-linux-x86_64
+          - os: macos-latest
+            artifact_name: katsustats-macos-arm64
+          - os: windows-latest
+            artifact_name: katsustats-windows-x86_64.exe
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          python-version-file: .python-version
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Install PyInstaller
+        run: uv pip install pyinstaller
+
+      - name: Build binary
+        shell: bash
+        run: >-
+          uv run pyinstaller
+          --onefile
+          --name katsustats
+          --collect-all polars
+          --hidden-import matplotlib.backends.backend_agg
+          src/katsustats/__main__.py
+
+      - name: Rename artifact (Unix)
+        if: runner.os != 'Windows'
+        run: mv dist/katsustats dist/${{ matrix.artifact_name }}
+
+      - name: Rename artifact (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: Move-Item dist\katsustats.exe dist\${{ matrix.artifact_name }}
+
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/${{ matrix.artifact_name }}

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -17,6 +17,9 @@ jobs:
           - os: windows-latest
             artifact_name: katsustats-windows-x86_64.exe
 
+    permissions:
+      contents: write
+
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,17 +2,19 @@
 
 ## Project overview
 
-katsustats is a Python library for generating backtest reports from financial return series. It takes a Polars DataFrame with `["date", "returns"]` columns and produces summary metrics, drawdown analysis, matplotlib charts, and self-contained HTML reports.
+katsustats is a Python library and CLI for generating backtest reports from financial return series. It takes a Polars DataFrame with `["date", "returns"]` columns (or a pandas DataFrame/Series) and produces summary metrics, drawdown analysis, matplotlib charts, and self-contained HTML reports.
 
 ## Architecture
 
-Three-module functional design in `src/katsustats/`:
+Functional design in `src/katsustats/`:
 
 - `stats.py` — Pure metric computation (Sharpe, CAGR, drawdowns, etc.)
 - `plots.py` — Matplotlib chart generation (8 chart types)
 - `reports.py` — Orchestration: `full()` for dict output, `html()` for HTML report
+- `_dataframe.py` — Input normalisation: `ensure_polars()` converts pandas DataFrames, pandas Series (with DatetimeIndex), and Polars DataFrames to the canonical `["date", "returns"]` Polars frame
+- `__main__.py` — CLI entry point (`katsustats report`); reads CSV/Parquet and calls `reports.html()`
 
-No classes. All functions expect a Polars DataFrame with `date: pl.Date` and `returns: pl.Float64` columns.
+No classes. All public functions accept a Polars DataFrame, pandas DataFrame, or pandas Series with `date` and `returns` data.
 
 ## Setup
 
@@ -23,7 +25,7 @@ uv sync --dev   # includes pytest + ruff
 - Python 3.13 (`.python-version`), requires >=3.9
 - Build backend: hatchling (src layout)
 - Dependencies: polars, numpy, matplotlib
-- Dev dependencies: pytest, ruff
+- Dev dependencies: pytest, ruff, pandas
 
 ## Build
 
@@ -36,7 +38,7 @@ uv build
 ```bash
 uv run ruff check src/ tests/         # lint
 uv run ruff format --check src/ tests/ # format check
-uv run pytest tests/ -v               # 113 tests across stats/plots/reports
+uv run pytest tests/ -v               # 265 tests across stats/plots/reports/cli
 ```
 
 CI runs on every PR and push to main (`.github/workflows/ci.yml`). All tests and ruff checks must pass before merging.
@@ -48,7 +50,8 @@ CI runs on every PR and push to main (`.github/workflows/ci.yml`). All tests and
 - snake_case functions, `_` prefix for private helpers
 - Short docstrings on all public functions
 - Section separators: `# ---...---` comment banners
-- Input validation via `assert` statements
+- Input validation via `assert` statements in library code; `sys.exit()` with user-facing messages in the CLI
+- pandas inputs (DataFrame with `date` column, DatetimeIndex DataFrame, or Series) are normalised in `_dataframe.py:ensure_polars()` — no changes needed in stats/plots/reports
 - Plot styling centralized in `_COLORS` dict with `_apply_style()` / `_add_title()` helpers
 - Purely functional — no OOP
 - Ruff: line-length=88, target py39, select E/W/F/I/UP, ignore E501

--- a/README.md
+++ b/README.md
@@ -43,14 +43,30 @@ Highlights:
 
 ## Installation
 
+**As a Python library:**
+
 ```bash
 pip install katsustats
+# or
+uv add katsustats
 ```
 
-Or with `uv`:
+**As a standalone CLI** (no script needed — just install and run):
 
 ```bash
-uv add katsustats
+pipx install katsustats   # recommended for CLI-only use
+# or
+uv tool install katsustats
+```
+
+**Standalone binary** (no Python needed at all):
+
+Download a pre-built binary for your platform from the [GitHub Releases page](https://github.com/katsu1110/katsustats/releases), make it executable, and run it directly:
+
+```bash
+# macOS / Linux
+chmod +x katsustats-linux-x86_64
+./katsustats-linux-x86_64 report trades.csv -o report.html
 ```
 
 ## Try it online
@@ -165,7 +181,7 @@ results = katsustats.reports.full(
 
 ## CLI
 
-Generate an HTML tearsheet directly from a CSV or Parquet file — no Python required:
+Generate an HTML tearsheet directly from a CSV or Parquet file — no script needed:
 
 ```bash
 # From a CSV file (date and returns columns)

--- a/README.md
+++ b/README.md
@@ -163,6 +163,26 @@ results = katsustats.reports.full(
 )
 ```
 
+## CLI
+
+Generate an HTML tearsheet directly from a CSV or Parquet file — no Python required:
+
+```bash
+# From a CSV file (date and returns columns)
+katsustats report trades.csv -o report.html
+
+# Custom column names
+katsustats report trades.csv --date-col day --returns-col pnl -o report.html
+
+# With a benchmark and a custom title
+katsustats report trades.csv --benchmark benchmark.csv --title "My Strategy" -o report.html
+
+# From a Parquet file with a custom risk-free rate
+katsustats report trades.parquet --rf 0.04 -o report.html
+```
+
+If `-o` is omitted the report is written alongside the input file (e.g. `trades.html`).
+
 ## HTML report
 
 Generate a self-contained HTML report (similar to `qs.reports.html()`):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ dependencies = [
     "matplotlib>=3.7.0",
 ]
 
+[project.scripts]
+katsustats = "katsustats.__main__:main"
+
 [project.urls]
 Homepage = "https://github.com/katsu1110/katsustats"
 Repository = "https://github.com/katsu1110/katsustats"

--- a/src/katsustats/__main__.py
+++ b/src/katsustats/__main__.py
@@ -1,0 +1,121 @@
+"""CLI entry point: ``katsustats report <file> [options]``."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import polars as pl
+
+from katsustats import reports
+
+
+def _load(path: str, date_col: str, returns_col: str) -> pl.DataFrame:
+    p = Path(path)
+    suffix = p.suffix.lower()
+    if suffix == ".parquet":
+        df = pl.read_parquet(p)
+    elif suffix == ".csv":
+        df = pl.read_csv(p, try_parse_dates=True)
+    else:
+        sys.exit(f"Unsupported file format '{suffix}'. Use .csv or .parquet.")
+
+    rename: dict[str, str] = {}
+    if date_col != "date":
+        rename[date_col] = "date"
+    if returns_col != "returns":
+        rename[returns_col] = "returns"
+    if rename:
+        df = df.rename(rename)
+
+    return df
+
+
+def _cmd_report(args: argparse.Namespace) -> None:
+    df = _load(args.file, args.date_col, args.returns_col)
+
+    benchmark = None
+    if args.benchmark:
+        benchmark = _load(
+            args.benchmark,
+            args.benchmark_date_col,
+            args.benchmark_returns_col,
+        )
+
+    output = args.output or str(Path(args.file).with_suffix(".html"))
+    reports.html(
+        df,
+        benchmark=benchmark,
+        rf=args.rf,
+        title=args.title,
+        output=output,
+    )
+    print(f"Report written to {output}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="katsustats",
+        description="Generate backtest tearsheet reports from return series files.",
+    )
+    sub = parser.add_subparsers(dest="command", metavar="COMMAND")
+    sub.required = True
+
+    p_report = sub.add_parser(
+        "report",
+        help="Generate a self-contained HTML tearsheet from a CSV or Parquet file.",
+    )
+    p_report.add_argument("file", help="Path to a .csv or .parquet returns file.")
+    p_report.add_argument(
+        "--title", default="Strategy", help="Report title (default: Strategy)."
+    )
+    p_report.add_argument(
+        "-o",
+        "--output",
+        default=None,
+        help="Output HTML file path (default: <file>.html).",
+    )
+    p_report.add_argument(
+        "--date-col",
+        default="date",
+        dest="date_col",
+        help="Name of the date column (default: date).",
+    )
+    p_report.add_argument(
+        "--returns-col",
+        default="returns",
+        dest="returns_col",
+        help="Name of the returns column (default: returns).",
+    )
+    p_report.add_argument(
+        "--rf",
+        type=float,
+        default=0.0,
+        help="Annualized risk-free rate (default: 0.0).",
+    )
+    p_report.add_argument(
+        "--benchmark",
+        default=None,
+        help="Path to a benchmark .csv or .parquet file.",
+    )
+    p_report.add_argument(
+        "--benchmark-date-col",
+        default="date",
+        dest="benchmark_date_col",
+        help="Benchmark date column name (default: date).",
+    )
+    p_report.add_argument(
+        "--benchmark-returns-col",
+        default="returns",
+        dest="benchmark_returns_col",
+        help="Benchmark returns column name (default: returns).",
+    )
+    p_report.set_defaults(func=_cmd_report)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/katsustats/__main__.py
+++ b/src/katsustats/__main__.py
@@ -13,6 +13,9 @@ from katsustats import reports
 
 def _load(path: str, date_col: str, returns_col: str) -> pl.DataFrame:
     p = Path(path)
+    if not p.exists():
+        sys.exit(f"{p}: file not found.")
+
     suffix = p.suffix.lower()
     if suffix == ".parquet":
         df = pl.read_parquet(p)
@@ -21,6 +24,14 @@ def _load(path: str, date_col: str, returns_col: str) -> pl.DataFrame:
     else:
         label = f"'{suffix}'" if suffix else "no extension"
         sys.exit(f"{p}: {label} is not supported. Use .csv or .parquet.")
+
+    missing = [c for c in [date_col, returns_col] if c not in df.columns]
+    if missing:
+        sys.exit(
+            f"{p}: column(s) {missing} not found. "
+            f"Available columns: {df.columns}. "
+            f"Use --date-col / --returns-col to specify the correct names."
+        )
 
     rename: dict[str, str] = {}
     if date_col != "date":

--- a/src/katsustats/__main__.py
+++ b/src/katsustats/__main__.py
@@ -19,7 +19,8 @@ def _load(path: str, date_col: str, returns_col: str) -> pl.DataFrame:
     elif suffix == ".csv":
         df = pl.read_csv(p, try_parse_dates=True)
     else:
-        sys.exit(f"Unsupported file format '{suffix}'. Use .csv or .parquet.")
+        label = f"'{suffix}'" if suffix else "no extension"
+        sys.exit(f"{p}: {label} is not supported. Use .csv or .parquet.")
 
     rename: dict[str, str] = {}
     if date_col != "date":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -99,7 +99,7 @@ class TestReportCommand:
         main()
         expected = csv_file.with_suffix(".html")
         assert expected.exists()
-        assert expected.read_text().startswith("<!DOCTYPE html>")
+        assert expected.read_text(encoding="utf-8").startswith("<!DOCTYPE html>")
 
     def test_custom_column_names(
         self, csv_file_custom_cols: Path, tmp_path: Path, monkeypatch
@@ -184,3 +184,38 @@ class TestReportCommand:
         with pytest.raises(SystemExit) as exc_info:
             main()
         assert "no extension" in str(exc_info.value)
+
+    def test_missing_file_exits_with_clear_message(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "katsustats",
+                "report",
+                str(tmp_path / "nonexistent.csv"),
+                "-o",
+                str(tmp_path / "out.html"),
+            ],
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert "file not found" in str(exc_info.value)
+
+    def test_missing_column_exits_with_clear_message(
+        self, csv_file: Path, tmp_path: Path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "katsustats",
+                "report",
+                str(csv_file),
+                "--returns-col",
+                "pnl",
+                "-o",
+                str(tmp_path / "out.html"),
+            ],
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert "pnl" in str(exc_info.value)
+        assert "--returns-col" in str(exc_info.value)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,173 @@
+"""Integration tests for the katsustats CLI."""
+
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from katsustats.__main__ import main
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_DATES = [datetime.date(2023, 1, 2) + datetime.timedelta(days=i) for i in range(20)]
+_RETURNS = [
+    0.01,
+    -0.005,
+    0.008,
+    -0.012,
+    0.003,
+    0.015,
+    -0.007,
+    0.002,
+    -0.004,
+    0.009,
+    -0.011,
+    0.006,
+    0.013,
+    -0.002,
+    0.004,
+    0.007,
+    -0.008,
+    0.001,
+    -0.003,
+    0.011,
+]
+
+
+@pytest.fixture
+def csv_file(tmp_path: Path) -> Path:
+    p = tmp_path / "returns.csv"
+    pl.DataFrame({"date": _DATES, "returns": _RETURNS}).write_csv(p)
+    return p
+
+
+@pytest.fixture
+def parquet_file(tmp_path: Path) -> Path:
+    p = tmp_path / "returns.parquet"
+    pl.DataFrame({"date": _DATES, "returns": _RETURNS}).write_parquet(p)
+    return p
+
+
+@pytest.fixture
+def csv_file_custom_cols(tmp_path: Path) -> Path:
+    p = tmp_path / "returns_custom.csv"
+    pl.DataFrame({"day": _DATES, "pnl": _RETURNS}).write_csv(p)
+    return p
+
+
+@pytest.fixture
+def benchmark_csv(tmp_path: Path) -> Path:
+    p = tmp_path / "benchmark.csv"
+    bench = [r * 0.6 for r in _RETURNS]
+    pl.DataFrame({"date": _DATES, "returns": bench}).write_csv(p)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestReportCommand:
+    def test_csv_produces_html(self, csv_file: Path, tmp_path: Path, monkeypatch):
+        out = tmp_path / "out.html"
+        monkeypatch.setattr(
+            "sys.argv", ["katsustats", "report", str(csv_file), "-o", str(out)]
+        )
+        main()
+        assert out.exists()
+        assert out.read_text().startswith("<!DOCTYPE html>")
+
+    def test_parquet_produces_html(
+        self, parquet_file: Path, tmp_path: Path, monkeypatch
+    ):
+        out = tmp_path / "out.html"
+        monkeypatch.setattr(
+            "sys.argv", ["katsustats", "report", str(parquet_file), "-o", str(out)]
+        )
+        main()
+        assert out.exists()
+        assert out.read_text().startswith("<!DOCTYPE html>")
+
+    def test_default_output_path(self, csv_file: Path, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["katsustats", "report", str(csv_file)])
+        main()
+        expected = csv_file.with_suffix(".html")
+        assert expected.exists()
+        assert expected.read_text().startswith("<!DOCTYPE html>")
+
+    def test_custom_column_names(
+        self, csv_file_custom_cols: Path, tmp_path: Path, monkeypatch
+    ):
+        out = tmp_path / "out.html"
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "katsustats",
+                "report",
+                str(csv_file_custom_cols),
+                "--date-col",
+                "day",
+                "--returns-col",
+                "pnl",
+                "-o",
+                str(out),
+            ],
+        )
+        main()
+        assert out.exists()
+        assert out.read_text().startswith("<!DOCTYPE html>")
+
+    def test_with_benchmark(
+        self, csv_file: Path, benchmark_csv: Path, tmp_path: Path, monkeypatch
+    ):
+        out = tmp_path / "out.html"
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "katsustats",
+                "report",
+                str(csv_file),
+                "--benchmark",
+                str(benchmark_csv),
+                "-o",
+                str(out),
+            ],
+        )
+        main()
+        assert out.exists()
+        assert out.read_text().startswith("<!DOCTYPE html>")
+
+    def test_custom_title_appears_in_output(
+        self, csv_file: Path, tmp_path: Path, monkeypatch
+    ):
+        out = tmp_path / "out.html"
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "katsustats",
+                "report",
+                str(csv_file),
+                "--title",
+                "My Alpha Strategy",
+                "-o",
+                str(out),
+            ],
+        )
+        main()
+        assert "My Alpha Strategy" in out.read_text()
+
+    def test_unsupported_extension_exits(self, tmp_path: Path, monkeypatch):
+        bad = tmp_path / "data.xlsx"
+        bad.write_text("")
+        monkeypatch.setattr(
+            "sys.argv",
+            ["katsustats", "report", str(bad), "-o", str(tmp_path / "out.html")],
+        )
+        with pytest.raises(SystemExit):
+            main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -81,7 +81,7 @@ class TestReportCommand:
         )
         main()
         assert out.exists()
-        assert out.read_text().startswith("<!DOCTYPE html>")
+        assert out.read_text(encoding="utf-8").startswith("<!DOCTYPE html>")
 
     def test_parquet_produces_html(
         self, parquet_file: Path, tmp_path: Path, monkeypatch
@@ -92,7 +92,7 @@ class TestReportCommand:
         )
         main()
         assert out.exists()
-        assert out.read_text().startswith("<!DOCTYPE html>")
+        assert out.read_text(encoding="utf-8").startswith("<!DOCTYPE html>")
 
     def test_default_output_path(self, csv_file: Path, monkeypatch):
         monkeypatch.setattr("sys.argv", ["katsustats", "report", str(csv_file)])
@@ -121,7 +121,7 @@ class TestReportCommand:
         )
         main()
         assert out.exists()
-        assert out.read_text().startswith("<!DOCTYPE html>")
+        assert out.read_text(encoding="utf-8").startswith("<!DOCTYPE html>")
 
     def test_with_benchmark(
         self, csv_file: Path, benchmark_csv: Path, tmp_path: Path, monkeypatch
@@ -141,7 +141,7 @@ class TestReportCommand:
         )
         main()
         assert out.exists()
-        assert out.read_text().startswith("<!DOCTYPE html>")
+        assert out.read_text(encoding="utf-8").startswith("<!DOCTYPE html>")
 
     def test_custom_title_appears_in_output(
         self, csv_file: Path, tmp_path: Path, monkeypatch
@@ -160,7 +160,7 @@ class TestReportCommand:
             ],
         )
         main()
-        assert "My Alpha Strategy" in out.read_text()
+        assert "My Alpha Strategy" in out.read_text(encoding="utf-8")
 
     def test_unsupported_extension_exits(self, tmp_path: Path, monkeypatch):
         bad = tmp_path / "data.xlsx"
@@ -169,5 +169,18 @@ class TestReportCommand:
             "sys.argv",
             ["katsustats", "report", str(bad), "-o", str(tmp_path / "out.html")],
         )
-        with pytest.raises(SystemExit):
+        with pytest.raises(SystemExit) as exc_info:
             main()
+        assert "not supported" in str(exc_info.value)
+        assert ".xlsx" in str(exc_info.value)
+
+    def test_no_extension_exits_with_clear_message(self, tmp_path: Path, monkeypatch):
+        bad = tmp_path / "data"
+        bad.write_text("")
+        monkeypatch.setattr(
+            "sys.argv",
+            ["katsustats", "report", str(bad), "-o", str(tmp_path / "out.html")],
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert "no extension" in str(exc_info.value)


### PR DESCRIPTION
Closes #9 (report subcommand; `compare` deferred until `reports.compare` exists).

## Summary

- New `src/katsustats/__main__.py` — ~80-line argparse CLI registered as a console script
- `katsustats report <file>` auto-detects `.csv` / `.parquet` by extension and writes a self-contained HTML tearsheet
- Flags: `--title`, `-o/--output`, `--date-col`, `--returns-col`, `--rf`, `--benchmark`, `--benchmark-date-col`, `--benchmark-returns-col`
- Omitting `-o` defaults output to `<input>.html` alongside the input file
- Console script registered in `pyproject.toml` so `katsustats report` works after `pip install`

## Test plan

- [ ] `test_csv_produces_html` — CSV input writes valid `<!DOCTYPE html>` output
- [ ] `test_parquet_produces_html` — Parquet input works
- [ ] `test_default_output_path` — output defaults to `<file>.html`
- [ ] `test_custom_column_names` — `--date-col` / `--returns-col` rename correctly
- [ ] `test_with_benchmark` — `--benchmark` flag wires through to `reports.html()`
- [ ] `test_custom_title_appears_in_output` — `--title` appears in HTML
- [ ] `test_unsupported_extension_exits` — `.xlsx` triggers `SystemExit` with clear message
- [ ] All 262 tests pass (`uv run pytest tests/ -v`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)