### PR TITLE
fix: show weekend bars in dow plot when data contains weekend dates

### DIFF
--- a/src/katsustats/plots.py
+++ b/src/katsustats/plots.py
@@ -694,8 +694,6 @@ def plot_dow_returns(df: DataFrameLike, figsize: tuple = (10, 5)) -> Figure:
     """Day-of-week bar chart showing mean return and win rate."""
     df = ensure_polars(df)
     dow_df = stats.day_of_week_stats(df)
-    # Filter to weekdays (1-5)
-    dow_df = dow_df.filter(pl.col("dow") <= 5)
 
     names = dow_df.get_column("dow_name").to_list()
     mean_ret = dow_df.get_column("mean_return").to_numpy()

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -320,6 +320,23 @@ class TestPlotDowReturns:
         fig = plots.plot_dow_returns(sample_df, figsize=(8, 4))
         assert isinstance(fig, Figure)
 
+    def test_weekends_shown_when_present(self):
+        """Bars for Sat/Sun appear when the data includes weekend dates."""
+        dates = [
+            "2024-01-01",  # Mon
+            "2024-01-02",  # Tue
+            "2024-01-06",  # Sat
+            "2024-01-07",  # Sun
+        ]
+        df = pl.DataFrame(
+            {"date": dates, "returns": [0.01, -0.01, 0.02, -0.02]}
+        ).with_columns(pl.col("date").cast(pl.Date))
+        fig = plots.plot_dow_returns(df)
+        ax = fig.axes[0]
+        bar_labels = [tick.get_text() for tick in ax.get_xticklabels()]
+        assert "Sat" in bar_labels
+        assert "Sun" in bar_labels
+
 
 # ---------------------------------------------------------------------------
 # plot_returns_vs_benchmark


### PR DESCRIPTION
## Summary

- `plot_dow_returns` was hard-filtering to `dow <= 5`, silently dropping Saturday/Sunday bars even when the input data included weekend dates (e.g. crypto markets)
- `day_of_week_stats` already returns only the days present in the data via `group_by`, so no filter is needed
- Added a test asserting Sat/Sun bars appear when weekend dates are in the data

## Test plan

- [ ] `uv run pytest tests/test_plots.py::TestPlotDowReturns -v` — all 3 tests pass
- [ ] `uv run pytest tests/ -v` — full suite passes
- [ ] `uv run ruff check src/ tests/` — no lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)