### PR TITLE
Add AI-friendly JSON report output

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Highlights:
 - Benchmark-aware performance comparison
 - Self-contained offline HTML reports
 - AI-friendly structured JSON reports
+- Readable Markdown summaries for humans and agents
 - Functional modules for `stats`, `plots`, and `reports`
 
 ## Preview
@@ -191,6 +192,9 @@ katsustats report trades.csv -o report.html
 # Structured JSON for AI agents / downstream tooling
 katsustats report trades.csv --format json -o report.json
 
+# Markdown summary for humans and agents
+katsustats report trades.csv --format markdown -o report.md
+
 # Custom column names
 katsustats report trades.csv --date-col day --returns-col pnl -o report.html
 
@@ -201,7 +205,7 @@ katsustats report trades.csv --benchmark benchmark.csv --title "My Strategy" -o 
 katsustats report trades.parquet --rf 0.04 -o report.html
 ```
 
-If `-o` is omitted the report is written alongside the input file (for example `trades.html` or `trades.json`).
+If `-o` is omitted the report is written alongside the input file (for example `trades.html`, `trades.json`, or `trades.md`).
 
 ## HTML report
 
@@ -234,6 +238,23 @@ json_str = katsustats.reports.json(returns, title="My Strategy")
 The JSON output is optimized for LLMs, agents, and other automation tools. It
 includes raw numeric metrics, structured period performance, top drawdowns,
 day-of-week statistics, and regime analysis when a benchmark is provided.
+
+## Markdown report
+
+Generate a Markdown backtest summary:
+
+```python
+# Save to file
+katsustats.reports.markdown(returns, benchmark=benchmark, title="My Strategy", output="report.md")
+
+# Or get Markdown string
+md_str = katsustats.reports.markdown(returns, title="My Strategy")
+```
+
+The Markdown output is designed to be readable in editors, GitHub, chat tools,
+and agent workflows. It includes an overview, headline metrics, performance
+tables, period performance, top drawdowns, day-of-week statistics, and optional
+regime analysis.
 
 ## Using individual modules
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Highlights:
 - Polars-first API with pandas input support
 - Benchmark-aware performance comparison
 - Self-contained offline HTML reports
+- AI-friendly structured JSON reports
 - Functional modules for `stats`, `plots`, and `reports`
 
 ## Preview
@@ -187,6 +188,9 @@ Generate an HTML tearsheet directly from a CSV or Parquet file — no script nee
 # From a CSV file (date and returns columns)
 katsustats report trades.csv -o report.html
 
+# Structured JSON for AI agents / downstream tooling
+katsustats report trades.csv --format json -o report.json
+
 # Custom column names
 katsustats report trades.csv --date-col day --returns-col pnl -o report.html
 
@@ -197,7 +201,7 @@ katsustats report trades.csv --benchmark benchmark.csv --title "My Strategy" -o 
 katsustats report trades.parquet --rf 0.04 -o report.html
 ```
 
-If `-o` is omitted the report is written alongside the input file (e.g. `trades.html`).
+If `-o` is omitted the report is written alongside the input file (for example `trades.html` or `trades.json`).
 
 ## HTML report
 
@@ -214,6 +218,22 @@ html_str = katsustats.reports.html(returns, title="My Strategy")
 The report includes headline metric cards, performance tables, period performance, drawdown analysis, day-of-week statistics, and all 8 charts embedded as images — all in a single `.html` file that works offline.
 
 When a benchmark is provided, the HTML report also includes regime analysis.
+
+## JSON report
+
+Generate an AI-friendly structured JSON report:
+
+```python
+# Save to file
+katsustats.reports.json(returns, benchmark=benchmark, title="My Strategy", output="report.json")
+
+# Or get JSON string
+json_str = katsustats.reports.json(returns, title="My Strategy")
+```
+
+The JSON output is optimized for LLMs, agents, and other automation tools. It
+includes raw numeric metrics, structured period performance, top drawdowns,
+day-of-week statistics, and regime analysis when a benchmark is provided.
 
 ## Using individual modules
 

--- a/src/katsustats/__init__.py
+++ b/src/katsustats/__init__.py
@@ -6,9 +6,10 @@ Usage:
     katsustats.reports.full(returns, benchmark)              # console + plots
     katsustats.reports.html(returns, output="report.html")   # HTML report
     katsustats.reports.json(returns, output="report.json")   # JSON report
+    katsustats.reports.markdown(returns, output="report.md") # Markdown report
 
     # Flat imports also work:
-    from katsustats import sharpe, plot_cumulative_returns, html, json_report
+    from katsustats import sharpe, plot_cumulative_returns, html, json_report, markdown_report
 """
 
 from __future__ import annotations
@@ -33,6 +34,7 @@ from .plots import (
 # reports
 from .reports import full, html
 from .reports import json as json_report
+from .reports import markdown as markdown_report
 
 # stats
 from .stats import (
@@ -148,4 +150,5 @@ __all__ = [
     "full",
     "html",
     "json_report",
+    "markdown_report",
 ]

--- a/src/katsustats/__init__.py
+++ b/src/katsustats/__init__.py
@@ -5,9 +5,10 @@ Usage:
     import katsustats
     katsustats.reports.full(returns, benchmark)              # console + plots
     katsustats.reports.html(returns, output="report.html")   # HTML report
+    katsustats.reports.json(returns, output="report.json")   # JSON report
 
     # Flat imports also work:
-    from katsustats import sharpe, plot_cumulative_returns, html
+    from katsustats import sharpe, plot_cumulative_returns, html, json_report
 """
 
 from __future__ import annotations
@@ -31,6 +32,7 @@ from .plots import (
 
 # reports
 from .reports import full, html
+from .reports import json as json_report
 
 # stats
 from .stats import (
@@ -145,4 +147,5 @@ __all__ = [
     # reports
     "full",
     "html",
+    "json_report",
 ]

--- a/src/katsustats/__main__.py
+++ b/src/katsustats/__main__.py
@@ -55,33 +55,22 @@ def _cmd_report(args: argparse.Namespace) -> None:
             args.benchmark_returns_col,
         )
 
-    default_suffix = {"html": ".html", "json": ".json", "markdown": ".md"}[args.format]
-    output = args.output or str(Path(args.file).with_suffix(default_suffix))
-
-    if args.format == "json":
-        reports.json(
-            df,
-            benchmark=benchmark,
-            rf=args.rf,
-            title=args.title,
-            output=output,
-        )
-    elif args.format == "markdown":
-        reports.markdown(
-            df,
-            benchmark=benchmark,
-            rf=args.rf,
-            title=args.title,
-            output=output,
-        )
-    else:
-        reports.html(
-            df,
-            benchmark=benchmark,
-            rf=args.rf,
-            title=args.title,
-            output=output,
-        )
+    _format_fn = {
+        "html": reports.html,
+        "json": reports.json,
+        "markdown": reports.markdown,
+    }
+    _format_suffix = {"html": ".html", "json": ".json", "markdown": ".md"}
+    output = args.output or str(
+        Path(args.file).with_suffix(_format_suffix[args.format])
+    )
+    _format_fn[args.format](
+        df,
+        benchmark=benchmark,
+        rf=args.rf,
+        title=args.title,
+        output=output,
+    )
     print(f"Report written to {output}")
 
 

--- a/src/katsustats/__main__.py
+++ b/src/katsustats/__main__.py
@@ -55,11 +55,19 @@ def _cmd_report(args: argparse.Namespace) -> None:
             args.benchmark_returns_col,
         )
 
-    default_suffix = ".json" if args.format == "json" else ".html"
+    default_suffix = {"html": ".html", "json": ".json", "markdown": ".md"}[args.format]
     output = args.output or str(Path(args.file).with_suffix(default_suffix))
 
     if args.format == "json":
         reports.json(
+            df,
+            benchmark=benchmark,
+            rf=args.rf,
+            title=args.title,
+            output=output,
+        )
+    elif args.format == "markdown":
+        reports.markdown(
             df,
             benchmark=benchmark,
             rf=args.rf,
@@ -87,7 +95,7 @@ def main() -> None:
 
     p_report = sub.add_parser(
         "report",
-        help="Generate an HTML or JSON backtest report from a CSV or Parquet file.",
+        help="Generate an HTML, JSON, or Markdown backtest report from a CSV or Parquet file.",
     )
     p_report.add_argument("file", help="Path to a .csv or .parquet returns file.")
     p_report.add_argument(
@@ -97,11 +105,11 @@ def main() -> None:
         "-o",
         "--output",
         default=None,
-        help="Output file path (default: <file>.html or <file>.json).",
+        help="Output file path (default: <file>.html, <file>.json, or <file>.md).",
     )
     p_report.add_argument(
         "--format",
-        choices=["html", "json"],
+        choices=["html", "json", "markdown"],
         default="html",
         help="Output report format (default: html).",
     )

--- a/src/katsustats/__main__.py
+++ b/src/katsustats/__main__.py
@@ -55,14 +55,25 @@ def _cmd_report(args: argparse.Namespace) -> None:
             args.benchmark_returns_col,
         )
 
-    output = args.output or str(Path(args.file).with_suffix(".html"))
-    reports.html(
-        df,
-        benchmark=benchmark,
-        rf=args.rf,
-        title=args.title,
-        output=output,
-    )
+    default_suffix = ".json" if args.format == "json" else ".html"
+    output = args.output or str(Path(args.file).with_suffix(default_suffix))
+
+    if args.format == "json":
+        reports.json(
+            df,
+            benchmark=benchmark,
+            rf=args.rf,
+            title=args.title,
+            output=output,
+        )
+    else:
+        reports.html(
+            df,
+            benchmark=benchmark,
+            rf=args.rf,
+            title=args.title,
+            output=output,
+        )
     print(f"Report written to {output}")
 
 
@@ -76,7 +87,7 @@ def main() -> None:
 
     p_report = sub.add_parser(
         "report",
-        help="Generate a self-contained HTML tearsheet from a CSV or Parquet file.",
+        help="Generate an HTML or JSON backtest report from a CSV or Parquet file.",
     )
     p_report.add_argument("file", help="Path to a .csv or .parquet returns file.")
     p_report.add_argument(
@@ -86,7 +97,13 @@ def main() -> None:
         "-o",
         "--output",
         default=None,
-        help="Output HTML file path (default: <file>.html).",
+        help="Output file path (default: <file>.html or <file>.json).",
+    )
+    p_report.add_argument(
+        "--format",
+        choices=["html", "json"],
+        default="html",
+        help="Output report format (default: html).",
     )
     p_report.add_argument(
         "--date-col",

--- a/src/katsustats/reports.py
+++ b/src/katsustats/reports.py
@@ -29,39 +29,6 @@ _COMPARISON_KEYS = {
     "excess_return",
 }
 
-_MARKDOWN_SUMMARY_SPECS = [
-    ("Total Return", "total_return", "pct"),
-    ("CAGR", "cagr", "pct"),
-    ("Sharpe Ratio", "sharpe", "float"),
-    ("Sortino Ratio", "sortino", "float"),
-    ("Max Drawdown", "max_drawdown", "pct"),
-    ("Calmar Ratio", "calmar", "float"),
-    ("Volatility (ann.)", "volatility", "pct"),
-    ("Win Rate", "win_rate", "pct"),
-    ("Profit Factor", "profit_factor", "float"),
-    ("Best Day", "best_day", "pct"),
-    ("Worst Day", "worst_day", "pct"),
-    ("Avg Win", "avg_win", "pct"),
-    ("Avg Loss", "avg_loss", "pct"),
-    ("Daily VaR (95%)", "value_at_risk", "pct"),
-    ("CVaR (95%)", "cvar", "pct"),
-    ("Recovery Factor", "recovery_factor", "float"),
-    ("Skewness", "skewness", "float"),
-    ("Kurtosis", "kurtosis", "float"),
-    ("Best Month", "best_month", "pct"),
-    ("Worst Month", "worst_month", "pct"),
-    ("Best Year", "best_year", "pct"),
-    ("Worst Year", "worst_year", "pct"),
-    ("Positive Months", "positive_months_pct", "pct"),
-    ("Positive Years", "positive_years_pct", "pct"),
-]
-_MARKDOWN_COMPARISON_SPECS = [
-    ("Alpha", "alpha", "pct"),
-    ("Beta", "beta", "float"),
-    ("Correlation", "correlation", "float"),
-    ("Information Ratio", "information_ratio", "float"),
-    ("Excess Return", "excess_return", "pct"),
-]
 _MARKDOWN_HEADLINE_SPECS = [
     ("Total Return", "total_return", "pct"),
     ("CAGR", "cagr", "pct"),
@@ -70,7 +37,6 @@ _MARKDOWN_HEADLINE_SPECS = [
     ("Volatility", "volatility", "pct"),
     ("Win Rate", "win_rate", "pct"),
 ]
-_PERIOD_LABELS = ("MTD", "QTD", "YTD", "1Y", "3Y", "5Y", "SI")
 
 
 def _print_df(df: pl.DataFrame, title: str = "") -> None:
@@ -166,6 +132,30 @@ def _df_to_html_table(df: pl.DataFrame, *, css_class: str = "metrics") -> str:
     return f'<table class="{css_class}">{"".join(rows_html)}</table>'
 
 
+def _validate_and_sort(
+    returns: DataFrameLike,
+    benchmark: DataFrameLike | None,
+) -> tuple[pl.DataFrame, pl.DataFrame | None]:
+    """Normalise, validate, and sort inputs; return (returns, benchmark) as Polars frames."""
+    returns = ensure_polars(returns, name="returns")
+    assert "date" in returns.columns, "returns must have a 'date' column"
+    assert "returns" in returns.columns, "returns must have a 'returns' column"
+    if benchmark is not None:
+        benchmark = ensure_polars(benchmark, name="benchmark")
+        assert "date" in benchmark.columns, "benchmark must have a 'date' column"
+        assert "returns" in benchmark.columns, "benchmark must have a 'returns' column"
+    returns = returns.sort("date")
+    assert returns["date"].n_unique() == returns.height, (
+        "Expected `returns` to have unique dates after `ensure_polars()` "
+        "normalization/compounding. If this fails, check the input for "
+        "duplicate same-date rows or investigate whether normalization "
+        "did not run as expected."
+    )
+    if benchmark is not None:
+        benchmark = benchmark.sort("date")
+    return returns, benchmark
+
+
 def _json_safe_value(value: object) -> object:
     """Convert Python / Polars values into JSON-safe primitives."""
     if value is None:
@@ -250,7 +240,7 @@ def _markdown_report(payload: dict[str, object]) -> str:
         perf_headers.append("Benchmark")
     perf_rows: list[list[str]] = []
     benchmark_summary = None if benchmark is None else benchmark["summary"]
-    for label, key, fmt in _MARKDOWN_SUMMARY_SPECS:
+    for label, key, fmt in stats._SUMMARY_METRIC_SPECS:
         row = [
             label,
             _format_markdown_value(summary.get(key), fmt),
@@ -259,7 +249,7 @@ def _markdown_report(payload: dict[str, object]) -> str:
             row.append(_format_markdown_value(benchmark_summary.get(key), fmt))
         perf_rows.append(row)
     if comparison is not None:
-        for label, key, fmt in _MARKDOWN_COMPARISON_SPECS:
+        for label, key, fmt in stats._COMPARISON_METRIC_SPECS:
             perf_rows.append(
                 [
                     label,
@@ -276,7 +266,7 @@ def _markdown_report(payload: dict[str, object]) -> str:
         period_headers.append("Benchmark")
     period_rows: list[list[str]] = []
     benchmark_periods = None if benchmark is None else benchmark["period_performance"]
-    for label in _PERIOD_LABELS:
+    for label in stats._PERIOD_LABELS:
         row = [
             label,
             _format_markdown_value(
@@ -399,9 +389,6 @@ def _report_payload(
     periods: int,
 ) -> dict[str, object]:
     """Build an AI-friendly structured report payload."""
-    strategy_summary = stats.summary_metrics_raw(returns, None, rf, periods)
-    strategy_periods = stats.period_performance_raw(returns, None)
-
     benchmark_summary: dict[str, float] | None = None
     benchmark_periods: dict[str, dict[str, float]] | None = None
     comparison: dict[str, float] | None = None
@@ -409,6 +396,9 @@ def _report_payload(
 
     if benchmark is not None:
         combined_summary = stats.summary_metrics_raw(returns, benchmark, rf, periods)
+        strategy_summary = {
+            k: v for k, v in combined_summary.items() if k not in _COMPARISON_KEYS
+        }
         comparison = {
             key: _json_safe_value(value)
             for key, value in combined_summary.items()
@@ -416,16 +406,16 @@ def _report_payload(
         }
         benchmark_summary = stats.summary_metrics_raw(benchmark, None, rf, periods)
         aligned_periods = stats.period_performance_raw(returns, benchmark)
-        strategy_periods = {
-            label: {"strategy": values["strategy"]}
-            for label, values in aligned_periods.items()
-        }
-        benchmark_periods = {
-            label: {"benchmark": values["benchmark"]}
-            for label, values in aligned_periods.items()
-        }
+        strategy_periods: dict[str, dict[str, object]] = {}
+        benchmark_periods = {}
+        for label, values in aligned_periods.items():
+            strategy_periods[label] = {"strategy": values["strategy"]}
+            benchmark_periods[label] = {"benchmark": values["benchmark"]}
         regime_df = stats.regime_stats(returns, benchmark, periods=periods)
         regime_analysis = _df_to_records(regime_df.filter(pl.col("n_days") > 0))
+    else:
+        strategy_summary = stats.summary_metrics_raw(returns, None, rf, periods)
+        strategy_periods = stats.period_performance_raw(returns, None)
 
     return {
         "metadata": _metadata_payload(
@@ -729,27 +719,7 @@ def full(
     Returns:
         dict with keys: "metrics", "drawdowns", "dow_stats", "figures"
     """
-    # Validate inputs
-    returns = ensure_polars(returns, name="returns")
-    assert "date" in returns.columns, "returns must have a 'date' column"
-    assert "returns" in returns.columns, "returns must have a 'returns' column"
-    if benchmark is not None:
-        benchmark = ensure_polars(benchmark, name="benchmark")
-        assert "date" in benchmark.columns, "benchmark must have a 'date' column"
-        assert "returns" in benchmark.columns, "benchmark must have a 'returns' column"
-
-    # Sort by date after normalization.
-    # ensure_polars() already compounds duplicate same-date rows with a warning,
-    # so this uniqueness check is a defensive sanity check.
-    returns = returns.sort("date")
-    assert returns["date"].n_unique() == returns.height, (
-        "returns dates are expected to be unique after ensure_polars() normalization "
-        "and compounding of duplicate same-date rows; if duplicates still exist, "
-        "this indicates an unexpected post-normalization state or a bug. "
-        "Please report this issue if it persists."
-    )
-    if benchmark is not None:
-        benchmark = benchmark.sort("date")
+    returns, benchmark = _validate_and_sort(returns, benchmark)
 
     # ── 1. Metrics Summary ──────────────────────────────────────────
     summary = stats.summary_metrics_raw(returns, benchmark, rf, periods)
@@ -888,23 +858,7 @@ def json(
         `benchmark.period_performance` are aligned to the common date overlap so
         the period windows remain directly comparable.
     """
-    returns = ensure_polars(returns, name="returns")
-    assert "date" in returns.columns, "returns must have a 'date' column"
-    assert "returns" in returns.columns, "returns must have a 'returns' column"
-    if benchmark is not None:
-        benchmark = ensure_polars(benchmark, name="benchmark")
-        assert "date" in benchmark.columns, "benchmark must have a 'date' column"
-        assert "returns" in benchmark.columns, "benchmark must have a 'returns' column"
-
-    returns = returns.sort("date")
-    assert returns["date"].n_unique() == returns.height, (
-        "Expected `returns` to have unique dates after `ensure_polars()` "
-        "normalization/compounding. If this fails, check the input for "
-        "duplicate same-date rows or investigate whether normalization "
-        "did not run as expected."
-    )
-    if benchmark is not None:
-        benchmark = benchmark.sort("date")
+    returns, benchmark = _validate_and_sort(returns, benchmark)
 
     rendered = _json_dumps(
         _report_payload(
@@ -947,23 +901,7 @@ def markdown(
         period performance, drawdowns, day-of-week statistics, and optional
         regime analysis when a benchmark is provided.
     """
-    returns = ensure_polars(returns, name="returns")
-    assert "date" in returns.columns, "returns must have a 'date' column"
-    assert "returns" in returns.columns, "returns must have a 'returns' column"
-    if benchmark is not None:
-        benchmark = ensure_polars(benchmark, name="benchmark")
-        assert "date" in benchmark.columns, "benchmark must have a 'date' column"
-        assert "returns" in benchmark.columns, "benchmark must have a 'returns' column"
-
-    returns = returns.sort("date")
-    assert returns["date"].n_unique() == returns.height, (
-        "Expected `returns` to have unique dates after `ensure_polars()` "
-        "normalization/compounding. If this fails, check the input for "
-        "duplicate same-date rows or investigate whether normalization "
-        "did not run as expected."
-    )
-    if benchmark is not None:
-        benchmark = benchmark.sort("date")
+    returns, benchmark = _validate_and_sort(returns, benchmark)
 
     rendered = _markdown_report(
         _report_payload(
@@ -991,27 +929,7 @@ def _build_html(
     output: str | None,
 ) -> str:
     """Internal: build the HTML report string."""
-    # Validate
-    returns = ensure_polars(returns, name="returns")
-    assert "date" in returns.columns, "returns must have a 'date' column"
-    assert "returns" in returns.columns, "returns must have a 'returns' column"
-    if benchmark is not None:
-        benchmark = ensure_polars(benchmark, name="benchmark")
-        assert "date" in benchmark.columns, "benchmark must have a 'date' column"
-        assert "returns" in benchmark.columns, "benchmark must have a 'returns' column"
-
-    # Sort by date after normalization.
-    # ensure_polars() already compounds duplicate same-date rows with a warning,
-    # so this uniqueness check is a defensive sanity check.
-    returns = returns.sort("date")
-    assert returns["date"].n_unique() == returns.height, (
-        "Expected `returns` to have unique dates after `ensure_polars()` "
-        "normalization/compounding. If this fails, check the input for "
-        "duplicate same-date rows or investigate whether normalization "
-        "did not run as expected."
-    )
-    if benchmark is not None:
-        benchmark = benchmark.sort("date")
+    returns, benchmark = _validate_and_sort(returns, benchmark)
 
     # ── Metadata ────────────────────────────────────────────────────
     dates = returns.get_column("date")

--- a/src/katsustats/reports.py
+++ b/src/katsustats/reports.py
@@ -195,7 +195,15 @@ def _report_payload(
             if key in _COMPARISON_KEYS
         }
         benchmark_summary = stats.summary_metrics_raw(benchmark, None, rf, periods)
-        benchmark_periods = stats.period_performance_raw(returns, benchmark)
+        aligned_periods = stats.period_performance_raw(returns, benchmark)
+        strategy_periods = {
+            label: {"strategy": values["strategy"]}
+            for label, values in aligned_periods.items()
+        }
+        benchmark_periods = {
+            label: {"benchmark": values["benchmark"]}
+            for label, values in aligned_periods.items()
+        }
         regime_df = stats.regime_stats(returns, benchmark, periods=periods)
         regime_analysis = _df_to_records(regime_df.filter(pl.col("n_days") > 0))
 
@@ -637,6 +645,28 @@ def json(
 
     Returns:
         The rendered JSON string.
+
+        Top-level keys:
+            metadata: Report metadata including title, date range, trading-day
+                count, risk-free rate, periods, and whether a benchmark exists.
+            strategy: Dict with raw numeric `summary` metrics and
+                `period_performance` keyed by period label.
+            benchmark: None when no benchmark is provided; otherwise a dict with
+                benchmark `summary` metrics and benchmark-aligned
+                `period_performance` values keyed by period label.
+            comparison: None when no benchmark is provided; otherwise raw
+                strategy-vs-benchmark comparison metrics such as `alpha`,
+                `beta`, `correlation`, `information_ratio`, and
+                `excess_return`.
+            drawdowns: List of top drawdown rows.
+            day_of_week_stats: List of day-of-week summary rows.
+            regime_analysis: Empty list when no benchmark is provided or no
+                regime rows are available; otherwise a list of regime summary
+                rows.
+
+        When a benchmark is provided, both `strategy.period_performance` and
+        `benchmark.period_performance` are aligned to the common date overlap so
+        the period windows remain directly comparable.
     """
     returns = ensure_polars(returns, name="returns")
     assert "date" in returns.columns, "returns must have a 'date' column"

--- a/src/katsustats/reports.py
+++ b/src/katsustats/reports.py
@@ -29,6 +29,49 @@ _COMPARISON_KEYS = {
     "excess_return",
 }
 
+_MARKDOWN_SUMMARY_SPECS = [
+    ("Total Return", "total_return", "pct"),
+    ("CAGR", "cagr", "pct"),
+    ("Sharpe Ratio", "sharpe", "float"),
+    ("Sortino Ratio", "sortino", "float"),
+    ("Max Drawdown", "max_drawdown", "pct"),
+    ("Calmar Ratio", "calmar", "float"),
+    ("Volatility (ann.)", "volatility", "pct"),
+    ("Win Rate", "win_rate", "pct"),
+    ("Profit Factor", "profit_factor", "float"),
+    ("Best Day", "best_day", "pct"),
+    ("Worst Day", "worst_day", "pct"),
+    ("Avg Win", "avg_win", "pct"),
+    ("Avg Loss", "avg_loss", "pct"),
+    ("Daily VaR (95%)", "value_at_risk", "pct"),
+    ("CVaR (95%)", "cvar", "pct"),
+    ("Recovery Factor", "recovery_factor", "float"),
+    ("Skewness", "skewness", "float"),
+    ("Kurtosis", "kurtosis", "float"),
+    ("Best Month", "best_month", "pct"),
+    ("Worst Month", "worst_month", "pct"),
+    ("Best Year", "best_year", "pct"),
+    ("Worst Year", "worst_year", "pct"),
+    ("Positive Months", "positive_months_pct", "pct"),
+    ("Positive Years", "positive_years_pct", "pct"),
+]
+_MARKDOWN_COMPARISON_SPECS = [
+    ("Alpha", "alpha", "pct"),
+    ("Beta", "beta", "float"),
+    ("Correlation", "correlation", "float"),
+    ("Information Ratio", "information_ratio", "float"),
+    ("Excess Return", "excess_return", "pct"),
+]
+_MARKDOWN_HEADLINE_SPECS = [
+    ("Total Return", "total_return", "pct"),
+    ("CAGR", "cagr", "pct"),
+    ("Sharpe", "sharpe", "float"),
+    ("Max Drawdown", "max_drawdown", "pct"),
+    ("Volatility", "volatility", "pct"),
+    ("Win Rate", "win_rate", "pct"),
+]
+_PERIOD_LABELS = ("MTD", "QTD", "YTD", "1Y", "3Y", "5Y", "SI")
+
 
 def _print_df(df: pl.DataFrame, title: str = "") -> None:
     """Pretty-print a Polars DataFrame as a formatted table."""
@@ -147,6 +190,183 @@ def _df_to_records(df: pl.DataFrame) -> list[dict[str, object]]:
 def _json_dumps(payload: dict[str, object]) -> str:
     """Serialize report payload to pretty JSON."""
     return _json.dumps(payload, indent=2, ensure_ascii=False, allow_nan=False)
+
+
+def _markdown_escape(value: object) -> str:
+    """Escape Markdown table delimiters in string values."""
+    return str(value).replace("|", r"\|")
+
+
+def _format_markdown_value(value: object, fmt: str) -> str:
+    """Format a value for Markdown output."""
+    if value is None:
+        return "—"
+    if fmt == "pct":
+        return f"{float(value):.2%}"
+    if fmt == "float":
+        return f"{float(value):.2f}"
+    if fmt == "int":
+        return str(int(value))
+    return _markdown_escape(value)
+
+
+def _markdown_table(headers: list[str], rows: list[list[str]]) -> str:
+    """Build a Markdown table from headers and preformatted rows."""
+    header_row = "| " + " | ".join(headers) + " |"
+    separator_row = "| " + " | ".join(["---"] * len(headers)) + " |"
+    body_rows = ["| " + " | ".join(row) + " |" for row in rows]
+    return "\n".join([header_row, separator_row, *body_rows])
+
+
+def _markdown_report(payload: dict[str, object]) -> str:
+    """Render a structured payload as a Markdown backtest summary."""
+    metadata = payload["metadata"]
+    strategy = payload["strategy"]
+    benchmark = payload["benchmark"]
+    comparison = payload["comparison"]
+    drawdowns = payload["drawdowns"]
+    dow_stats = payload["day_of_week_stats"]
+    regime_analysis = payload["regime_analysis"]
+
+    summary = strategy["summary"]
+    lines = [
+        f"# {_markdown_escape(metadata['title'])} Backtest Summary",
+        "",
+        "## Overview",
+        f"- Period: {_markdown_escape(metadata['start_date'])} to {_markdown_escape(metadata['end_date'])}",
+        f"- Trading days: {_format_markdown_value(metadata['n_days'], 'int')}",
+        f"- Benchmark: {'Yes' if metadata['has_benchmark'] else 'No'}",
+        f"- Risk-free rate: {_format_markdown_value(metadata['rf'], 'pct')}",
+        f"- Periods per year: {_format_markdown_value(metadata['periods'], 'int')}",
+        "",
+        "## Headline Metrics",
+    ]
+    for label, key, fmt in _MARKDOWN_HEADLINE_SPECS:
+        lines.append(f"- {label}: {_format_markdown_value(summary.get(key), fmt)}")
+
+    lines.extend(["", "## Performance Metrics"])
+    perf_headers = ["Metric", "Strategy"]
+    if benchmark is not None:
+        perf_headers.append("Benchmark")
+    perf_rows: list[list[str]] = []
+    benchmark_summary = None if benchmark is None else benchmark["summary"]
+    for label, key, fmt in _MARKDOWN_SUMMARY_SPECS:
+        row = [
+            label,
+            _format_markdown_value(summary.get(key), fmt),
+        ]
+        if benchmark_summary is not None:
+            row.append(_format_markdown_value(benchmark_summary.get(key), fmt))
+        perf_rows.append(row)
+    if comparison is not None:
+        for label, key, fmt in _MARKDOWN_COMPARISON_SPECS:
+            perf_rows.append(
+                [
+                    label,
+                    _format_markdown_value(comparison.get(key), fmt),
+                    "—",
+                ]
+            )
+    lines.extend(
+        [_markdown_table(perf_headers, perf_rows), "", "## Period Performance"]
+    )
+
+    period_headers = ["Period", "Strategy"]
+    if benchmark is not None:
+        period_headers.append("Benchmark")
+    period_rows: list[list[str]] = []
+    benchmark_periods = None if benchmark is None else benchmark["period_performance"]
+    for label in _PERIOD_LABELS:
+        row = [
+            label,
+            _format_markdown_value(
+                strategy["period_performance"][label].get("strategy"), "pct"
+            ),
+        ]
+        if benchmark_periods is not None:
+            row.append(
+                _format_markdown_value(benchmark_periods[label].get("benchmark"), "pct")
+            )
+        period_rows.append(row)
+    lines.extend([_markdown_table(period_headers, period_rows), ""])
+
+    if drawdowns:
+        lines.extend(["## Top Drawdowns"])
+        drawdown_rows = [
+            [
+                _format_markdown_value(row.get("start"), "str"),
+                _format_markdown_value(row.get("trough"), "str"),
+                _format_markdown_value(row.get("recovery"), "str"),
+                _format_markdown_value(row.get("max_dd"), "pct"),
+                _format_markdown_value(row.get("drawdown_days"), "int"),
+                _format_markdown_value(row.get("recovery_days"), "int"),
+            ]
+            for row in drawdowns
+        ]
+        lines.extend(
+            [
+                _markdown_table(
+                    [
+                        "Start",
+                        "Trough",
+                        "Recovery",
+                        "Max DD",
+                        "Drawdown Days",
+                        "Recovery Days",
+                    ],
+                    drawdown_rows,
+                ),
+                "",
+            ]
+        )
+
+    if dow_stats:
+        lines.extend(["## Day-of-Week Statistics"])
+        dow_rows = [
+            [
+                _format_markdown_value(row.get("dow_name"), "str"),
+                _format_markdown_value(row.get("mean_return"), "pct"),
+                _format_markdown_value(row.get("win_rate"), "pct"),
+                _format_markdown_value(row.get("total_return"), "pct"),
+                _format_markdown_value(row.get("count"), "int"),
+            ]
+            for row in dow_stats
+        ]
+        lines.extend(
+            [
+                _markdown_table(
+                    ["Day", "Mean Return", "Win Rate", "Total Return", "Count"],
+                    dow_rows,
+                ),
+                "",
+            ]
+        )
+
+    if regime_analysis:
+        lines.extend(["## Regime Analysis"])
+        regime_rows = [
+            [
+                _format_markdown_value(row.get("regime"), "str"),
+                _format_markdown_value(row.get("n_days"), "int"),
+                _format_markdown_value(row.get("cagr"), "pct"),
+                _format_markdown_value(row.get("sharpe"), "float"),
+                _format_markdown_value(row.get("max_drawdown"), "pct"),
+                _format_markdown_value(row.get("win_rate"), "pct"),
+            ]
+            for row in regime_analysis
+        ]
+        lines.extend(
+            [
+                _markdown_table(
+                    ["Regime", "Days", "CAGR", "Sharpe", "Max Drawdown", "Win Rate"],
+                    regime_rows,
+                ),
+                "",
+            ]
+        )
+
+    lines.append("Generated by katsustats")
+    return "\n".join(lines).strip() + "\n"
 
 
 def _metadata_payload(
@@ -687,6 +907,65 @@ def json(
         benchmark = benchmark.sort("date")
 
     rendered = _json_dumps(
+        _report_payload(
+            returns,
+            benchmark,
+            title=title,
+            rf=rf,
+            periods=periods,
+        )
+    )
+
+    if output is not None:
+        with open(output, "w", encoding="utf-8") as f:
+            f.write(rendered)
+
+    return rendered
+
+
+def markdown(
+    returns: DataFrameLike,
+    benchmark: DataFrameLike | None = None,
+    rf: float = 0.0,
+    periods: int = 252,
+    title: str = "Strategy",
+    output: str | None = None,
+) -> str:
+    """
+    Generate a Markdown backtest summary for humans and AI agents.
+
+    Args:
+        returns: Polars or pandas DataFrame with ["date", "returns"] columns.
+        benchmark: Optional benchmark DataFrame with the same schema.
+        rf: Risk-free rate (annualized, default 0.0).
+        periods: Trading days per year (default 252).
+        title: Report title (default "Strategy").
+        output: File path to write Markdown. If None, only returns the Markdown.
+
+    Returns:
+        A Markdown string with overview, headline metrics, performance tables,
+        period performance, drawdowns, day-of-week statistics, and optional
+        regime analysis when a benchmark is provided.
+    """
+    returns = ensure_polars(returns, name="returns")
+    assert "date" in returns.columns, "returns must have a 'date' column"
+    assert "returns" in returns.columns, "returns must have a 'returns' column"
+    if benchmark is not None:
+        benchmark = ensure_polars(benchmark, name="benchmark")
+        assert "date" in benchmark.columns, "benchmark must have a 'date' column"
+        assert "returns" in benchmark.columns, "benchmark must have a 'returns' column"
+
+    returns = returns.sort("date")
+    assert returns["date"].n_unique() == returns.height, (
+        "Expected `returns` to have unique dates after `ensure_polars()` "
+        "normalization/compounding. If this fails, check the input for "
+        "duplicate same-date rows or investigate whether normalization "
+        "did not run as expected."
+    )
+    if benchmark is not None:
+        benchmark = benchmark.sort("date")
+
+    rendered = _markdown_report(
         _report_payload(
             returns,
             benchmark,

--- a/src/katsustats/reports.py
+++ b/src/katsustats/reports.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import base64
 import datetime as _dt
 import io
+import json as _json
 import math
 
 import matplotlib
@@ -19,6 +20,14 @@ import polars as pl
 
 from . import plots, stats
 from ._dataframe import DataFrameLike, ensure_polars
+
+_COMPARISON_KEYS = {
+    "alpha",
+    "beta",
+    "correlation",
+    "information_ratio",
+    "excess_return",
+}
 
 
 def _print_df(df: pl.DataFrame, title: str = "") -> None:
@@ -112,6 +121,124 @@ def _df_to_html_table(df: pl.DataFrame, *, css_class: str = "metrics") -> str:
         rows_html.append(f"<tr>{cells}</tr>")
 
     return f'<table class="{css_class}">{"".join(rows_html)}</table>'
+
+
+def _json_safe_value(value: object) -> object:
+    """Convert Python / Polars values into JSON-safe primitives."""
+    if value is None:
+        return None
+    if isinstance(value, (_dt.datetime, _dt.date)):
+        return value.isoformat()
+    if isinstance(value, float):
+        if math.isnan(value) or math.isinf(value):
+            return None
+        return value
+    return value
+
+
+def _df_to_records(df: pl.DataFrame) -> list[dict[str, object]]:
+    """Convert a Polars DataFrame to a list of JSON-safe row dicts."""
+    return [
+        {key: _json_safe_value(value) for key, value in row.items()}
+        for row in df.to_dicts()
+    ]
+
+
+def _json_dumps(payload: dict[str, object]) -> str:
+    """Serialize report payload to pretty JSON."""
+    return _json.dumps(payload, indent=2, ensure_ascii=False, allow_nan=False)
+
+
+def _metadata_payload(
+    returns: pl.DataFrame,
+    benchmark: pl.DataFrame | None,
+    *,
+    title: str,
+    rf: float,
+    periods: int,
+) -> dict[str, object]:
+    """Build shared metadata for structured report outputs."""
+    dates = returns.get_column("date")
+    return {
+        "title": title,
+        "start_date": _json_safe_value(dates.min()),
+        "end_date": _json_safe_value(dates.max()),
+        "n_days": returns.height,
+        "rf": rf,
+        "periods": periods,
+        "has_benchmark": benchmark is not None,
+    }
+
+
+def _report_payload(
+    returns: pl.DataFrame,
+    benchmark: pl.DataFrame | None,
+    *,
+    title: str,
+    rf: float,
+    periods: int,
+) -> dict[str, object]:
+    """Build an AI-friendly structured report payload."""
+    strategy_summary = stats.summary_metrics_raw(returns, None, rf, periods)
+    strategy_periods = stats.period_performance_raw(returns, None)
+
+    benchmark_summary: dict[str, float] | None = None
+    benchmark_periods: dict[str, dict[str, float]] | None = None
+    comparison: dict[str, float] | None = None
+    regime_analysis: list[dict[str, object]] = []
+
+    if benchmark is not None:
+        combined_summary = stats.summary_metrics_raw(returns, benchmark, rf, periods)
+        comparison = {
+            key: _json_safe_value(value)
+            for key, value in combined_summary.items()
+            if key in _COMPARISON_KEYS
+        }
+        benchmark_summary = stats.summary_metrics_raw(benchmark, None, rf, periods)
+        benchmark_periods = stats.period_performance_raw(returns, benchmark)
+        regime_df = stats.regime_stats(returns, benchmark, periods=periods)
+        regime_analysis = _df_to_records(regime_df.filter(pl.col("n_days") > 0))
+
+    return {
+        "metadata": _metadata_payload(
+            returns,
+            benchmark,
+            title=title,
+            rf=rf,
+            periods=periods,
+        ),
+        "strategy": {
+            "summary": {
+                key: _json_safe_value(value) for key, value in strategy_summary.items()
+            },
+            "period_performance": {
+                label: {key: _json_safe_value(value) for key, value in values.items()}
+                for label, values in strategy_periods.items()
+            },
+        },
+        "benchmark": (
+            None
+            if benchmark is None
+            else {
+                "summary": {
+                    key: _json_safe_value(value)
+                    for key, value in benchmark_summary.items()
+                },
+                "period_performance": {
+                    label: {
+                        key: _json_safe_value(value)
+                        for key, value in values.items()
+                        if key == "benchmark"
+                    }
+                    for label, values in benchmark_periods.items()
+                },
+            }
+        ),
+        "comparison": comparison,
+        "drawdowns": _df_to_records(stats.drawdown_details(returns)),
+        "day_of_week_stats": _df_to_records(stats.day_of_week_stats(returns)),
+        "regime_analysis": regime_analysis,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -487,6 +614,63 @@ def html(
         return _build_html(returns, benchmark, rf, periods, title, output)
     finally:
         plt.switch_backend(orig_backend)
+
+
+def json(
+    returns: DataFrameLike,
+    benchmark: DataFrameLike | None = None,
+    rf: float = 0.0,
+    periods: int = 252,
+    title: str = "Strategy",
+    output: str | None = None,
+) -> str:
+    """
+    Generate an AI-friendly JSON backtest report.
+
+    Args:
+        returns: Polars or pandas DataFrame with ["date", "returns"] columns.
+        benchmark: Optional benchmark DataFrame with the same schema.
+        rf: Risk-free rate (annualized, default 0.0).
+        periods: Trading days per year (default 252).
+        title: Report title (default "Strategy").
+        output: File path to write JSON. If None, only returns the JSON string.
+
+    Returns:
+        The rendered JSON string.
+    """
+    returns = ensure_polars(returns, name="returns")
+    assert "date" in returns.columns, "returns must have a 'date' column"
+    assert "returns" in returns.columns, "returns must have a 'returns' column"
+    if benchmark is not None:
+        benchmark = ensure_polars(benchmark, name="benchmark")
+        assert "date" in benchmark.columns, "benchmark must have a 'date' column"
+        assert "returns" in benchmark.columns, "benchmark must have a 'returns' column"
+
+    returns = returns.sort("date")
+    assert returns["date"].n_unique() == returns.height, (
+        "Expected `returns` to have unique dates after `ensure_polars()` "
+        "normalization/compounding. If this fails, check the input for "
+        "duplicate same-date rows or investigate whether normalization "
+        "did not run as expected."
+    )
+    if benchmark is not None:
+        benchmark = benchmark.sort("date")
+
+    rendered = _json_dumps(
+        _report_payload(
+            returns,
+            benchmark,
+            title=title,
+            rf=rf,
+            periods=periods,
+        )
+    )
+
+    if output is not None:
+        with open(output, "w", encoding="utf-8") as f:
+            f.write(rendered)
+
+    return rendered
 
 
 def _build_html(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -132,6 +132,36 @@ class TestReportCommand:
         payload = json.loads(expected.read_text(encoding="utf-8"))
         assert payload["metadata"]["title"] == "Strategy"
 
+    def test_markdown_output_format(self, csv_file: Path, tmp_path: Path, monkeypatch):
+        out = tmp_path / "out.md"
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "katsustats",
+                "report",
+                str(csv_file),
+                "--format",
+                "markdown",
+                "-o",
+                str(out),
+            ],
+        )
+        main()
+        assert out.exists()
+        assert out.read_text(encoding="utf-8").startswith("# Strategy Backtest Summary")
+
+    def test_markdown_default_output_path(self, csv_file: Path, monkeypatch):
+        monkeypatch.setattr(
+            "sys.argv",
+            ["katsustats", "report", str(csv_file), "--format", "markdown"],
+        )
+        main()
+        expected = csv_file.with_suffix(".md")
+        assert expected.exists()
+        assert expected.read_text(encoding="utf-8").startswith(
+            "# Strategy Backtest Summary"
+        )
+
     def test_custom_column_names(
         self, csv_file_custom_cols: Path, tmp_path: Path, monkeypatch
     ):
@@ -196,6 +226,28 @@ class TestReportCommand:
         payload = json.loads(out.read_text(encoding="utf-8"))
         assert payload["benchmark"] is not None
         assert payload["comparison"] is not None
+
+    def test_markdown_with_benchmark(
+        self, csv_file: Path, benchmark_csv: Path, tmp_path: Path, monkeypatch
+    ):
+        out = tmp_path / "out.md"
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "katsustats",
+                "report",
+                str(csv_file),
+                "--benchmark",
+                str(benchmark_csv),
+                "--format",
+                "markdown",
+                "-o",
+                str(out),
+            ],
+        )
+        main()
+        text = out.read_text(encoding="utf-8")
+        assert "| Metric | Strategy | Benchmark |" in text
 
     def test_custom_title_appears_in_output(
         self, csv_file: Path, tmp_path: Path, monkeypatch

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime
+import json
 from pathlib import Path
 
 import polars as pl
@@ -101,6 +102,36 @@ class TestReportCommand:
         assert expected.exists()
         assert expected.read_text(encoding="utf-8").startswith("<!DOCTYPE html>")
 
+    def test_json_output_format(self, csv_file: Path, tmp_path: Path, monkeypatch):
+        out = tmp_path / "out.json"
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "katsustats",
+                "report",
+                str(csv_file),
+                "--format",
+                "json",
+                "-o",
+                str(out),
+            ],
+        )
+        main()
+        assert out.exists()
+        payload = json.loads(out.read_text(encoding="utf-8"))
+        assert payload["metadata"]["has_benchmark"] is False
+
+    def test_json_default_output_path(self, csv_file: Path, monkeypatch):
+        monkeypatch.setattr(
+            "sys.argv",
+            ["katsustats", "report", str(csv_file), "--format", "json"],
+        )
+        main()
+        expected = csv_file.with_suffix(".json")
+        assert expected.exists()
+        payload = json.loads(expected.read_text(encoding="utf-8"))
+        assert payload["metadata"]["title"] == "Strategy"
+
     def test_custom_column_names(
         self, csv_file_custom_cols: Path, tmp_path: Path, monkeypatch
     ):
@@ -142,6 +173,29 @@ class TestReportCommand:
         main()
         assert out.exists()
         assert out.read_text(encoding="utf-8").startswith("<!DOCTYPE html>")
+
+    def test_json_with_benchmark(
+        self, csv_file: Path, benchmark_csv: Path, tmp_path: Path, monkeypatch
+    ):
+        out = tmp_path / "out.json"
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "katsustats",
+                "report",
+                str(csv_file),
+                "--benchmark",
+                str(benchmark_csv),
+                "--format",
+                "json",
+                "-o",
+                str(out),
+            ],
+        )
+        main()
+        payload = json.loads(out.read_text(encoding="utf-8"))
+        assert payload["benchmark"] is not None
+        assert payload["comparison"] is not None
 
     def test_custom_title_appears_in_output(
         self, csv_file: Path, tmp_path: Path, monkeypatch

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -363,3 +363,66 @@ class TestJson:
         assert json.loads(result)["strategy"]["summary"][
             "total_return"
         ] == pytest.approx((1.10 * 1.20) * 0.90 - 1.0)
+
+
+# ---------------------------------------------------------------------------
+# reports.markdown
+# ---------------------------------------------------------------------------
+
+
+class TestMarkdown:
+    def test_returns_markdown_string(self, sample_df):
+        result = reports.markdown(sample_df)
+        assert isinstance(result, str)
+
+    def test_contains_core_sections(self, sample_df):
+        result = reports.markdown(sample_df, title="My Strategy")
+        assert result.startswith("# My Strategy Backtest Summary")
+        assert "## Overview" in result
+        assert "## Headline Metrics" in result
+        assert "## Performance Metrics" in result
+        assert "## Period Performance" in result
+        assert "## Day-of-Week Statistics" in result
+
+    def test_with_benchmark_includes_benchmark_sections(self, sample_df, benchmark_df):
+        result = reports.markdown(sample_df, benchmark=benchmark_df)
+        assert "| Metric | Strategy | Benchmark |" in result
+        assert "## Regime Analysis" not in result
+
+    def test_with_regime_data_includes_regime_section(self):
+        from datetime import date, timedelta
+
+        import numpy as np
+
+        rng = np.random.default_rng(0)
+        n = 600
+        dates = [date(2020, 1, 1) + timedelta(days=i) for i in range(n)]
+        strat = pl.DataFrame(
+            {"date": dates, "returns": rng.normal(0.0008, 0.012, n).tolist()}
+        ).with_columns(pl.col("date").cast(pl.Date))
+        bench = pl.DataFrame(
+            {"date": dates, "returns": rng.normal(0.0004, 0.009, n).tolist()}
+        ).with_columns(pl.col("date").cast(pl.Date))
+
+        result = reports.markdown(strat, benchmark=bench)
+        assert "## Regime Analysis" in result
+        assert "bull_low_vol" in result or "bear_low_vol" in result
+
+    def test_output_writes_markdown_file(self, sample_df, tmp_path):
+        out_file = tmp_path / "report.md"
+        result = reports.markdown(sample_df, output=str(out_file))
+        assert out_file.exists()
+        assert out_file.read_text(encoding="utf-8") == result
+
+    def test_duplicate_dates_warns_and_aggregates(self):
+        duplicate_dates_df = pl.DataFrame(
+            {
+                "date": ["2023-01-02", "2023-01-02", "2023-01-03"],
+                "returns": [0.10, 0.20, -0.10],
+            }
+        ).with_columns(pl.col("date").cast(pl.Date))
+
+        with pytest.warns(UserWarning, match="duplicate dates"):
+            result = reports.markdown(duplicate_dates_df)
+
+        assert "18.80%" in result

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -315,6 +315,21 @@ class TestJson:
         assert payload["comparison"] is not None
         assert "alpha" in payload["comparison"]
 
+    def test_with_benchmark_gaps_aligns_period_performance(
+        self, sample_df, benchmark_df
+    ):
+        gap_benchmark = benchmark_df.slice(5, benchmark_df.height - 5)
+
+        payload = json.loads(reports.json(sample_df, benchmark=gap_benchmark))
+        aligned = stats.period_performance_raw(sample_df, gap_benchmark)
+
+        assert payload["strategy"]["period_performance"]["SI"][
+            "strategy"
+        ] == pytest.approx(aligned["SI"]["strategy"])
+        assert payload["benchmark"]["period_performance"]["SI"][
+            "benchmark"
+        ] == pytest.approx(aligned["SI"]["benchmark"])
+
     def test_without_benchmark_uses_null_sections(self, sample_df):
         payload = json.loads(reports.json(sample_df))
         assert payload["benchmark"] is None

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 import matplotlib.pyplot as plt
 import polars as pl
 import pytest
@@ -274,3 +276,75 @@ class TestHtml:
                 {"date": ["2023-01-02", "2023-01-03"], "returns": [0.32, -0.10]}
             ).with_columns(pl.col("date").cast(pl.Date))
         )
+
+
+# ---------------------------------------------------------------------------
+# reports.json
+# ---------------------------------------------------------------------------
+
+
+class TestJson:
+    def test_returns_json_string(self, sample_df):
+        result = reports.json(sample_df)
+        payload = json.loads(result)
+        assert isinstance(payload, dict)
+
+    def test_contains_expected_top_level_keys(self, sample_df):
+        payload = json.loads(reports.json(sample_df, title="AI Report"))
+        assert set(payload.keys()) == {
+            "metadata",
+            "strategy",
+            "benchmark",
+            "comparison",
+            "drawdowns",
+            "day_of_week_stats",
+            "regime_analysis",
+        }
+        assert payload["metadata"]["title"] == "AI Report"
+        assert payload["metadata"]["has_benchmark"] is False
+
+    def test_strategy_summary_matches_raw_metrics(self, sample_df):
+        payload = json.loads(reports.json(sample_df))
+        assert payload["strategy"]["summary"] == stats.summary_metrics_raw(sample_df)
+
+    def test_with_benchmark_includes_benchmark_and_comparison(
+        self, sample_df, benchmark_df
+    ):
+        payload = json.loads(reports.json(sample_df, benchmark=benchmark_df))
+        assert payload["benchmark"] is not None
+        assert payload["comparison"] is not None
+        assert "alpha" in payload["comparison"]
+
+    def test_without_benchmark_uses_null_sections(self, sample_df):
+        payload = json.loads(reports.json(sample_df))
+        assert payload["benchmark"] is None
+        assert payload["comparison"] is None
+        assert payload["regime_analysis"] == []
+
+    def test_output_writes_json_file(self, sample_df, tmp_path):
+        out_file = tmp_path / "report.json"
+        result = reports.json(sample_df, output=str(out_file))
+        assert out_file.exists()
+        assert out_file.read_text(encoding="utf-8") == result
+        assert json.loads(result)["metadata"]["title"] == "Strategy"
+
+    def test_dates_are_iso_strings(self, sample_df):
+        payload = json.loads(reports.json(sample_df))
+        assert payload["metadata"]["start_date"] == "2023-01-02"
+        if payload["drawdowns"]:
+            assert isinstance(payload["drawdowns"][0]["start"], str)
+
+    def test_duplicate_dates_warns_and_aggregates(self):
+        duplicate_dates_df = pl.DataFrame(
+            {
+                "date": ["2023-01-02", "2023-01-02", "2023-01-03"],
+                "returns": [0.10, 0.20, -0.10],
+            }
+        ).with_columns(pl.col("date").cast(pl.Date))
+
+        with pytest.warns(UserWarning, match="duplicate dates"):
+            result = reports.json(duplicate_dates_df)
+
+        assert json.loads(result)["strategy"]["summary"][
+            "total_return"
+        ] == pytest.approx((1.10 * 1.20) * 0.90 - 1.0)


### PR DESCRIPTION
## Summary
- add `katsustats.reports.json()` for AI-friendly structured backtest output
- add CLI `--format json` support with `.json` default output paths
- document the JSON report format and add API/CLI coverage tests

## Validation
- `uv run ruff check src/ tests/`
- `uv run pytest tests/ -q`