### PR TITLE
docs: fix chart count in CLAUDE.md (8 → 13)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ katsustats is a Python library and CLI for generating backtest reports from fina
 Functional design in `src/katsustats/`:
 
 - `stats.py` — Pure metric computation (Sharpe, CAGR, drawdowns, etc.)
-- `plots.py` — Matplotlib chart generation (8 chart types)
+- `plots.py` — Matplotlib chart generation (13 chart types)
 - `reports.py` — Orchestration: `full()` for dict output, `html()` for HTML report
 - `_dataframe.py` — Input normalisation: `ensure_polars()` converts pandas DataFrames, pandas Series (with DatetimeIndex), and Polars DataFrames to the canonical `["date", "returns"]` Polars frame
 - `__main__.py` — CLI entry point (`katsustats report`); reads CSV/Parquet and calls `reports.html()`


### PR DESCRIPTION
## Summary

- Fix `plots.py` description in `CLAUDE.md`: was "8 chart types" but the module currently exports 13 public chart functions (`plot_cumulative_returns`, `plot_drawdown`, `plot_drawdown_periods`, `plot_monthly_heatmap`, `plot_yearly_returns`, `plot_eoy_returns`, `plot_return_distribution`, `plot_rolling_sharpe`, `plot_rolling_volatility`, `plot_returns_vs_benchmark`, `plot_dow_returns`, `plot_monte_carlo`, `plot_monte_carlo_distribution`)

## Test plan

- [ ] Confirm `plots.py` public function count matches the updated description
- [ ] No functional code changed

---
_Generated by [Claude Code](https://claude.ai/code/session_01X6Bvxwc8w5Y5RyJeQejdQr)_