### PR TITLE
docs: fix CLAUDE.md to reflect all report output formats

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project overview
 
-katsustats is a Python library and CLI for generating backtest reports from financial return series. It takes a Polars DataFrame with `["date", "returns"]` columns (or a pandas DataFrame/Series) and produces summary metrics, drawdown analysis, matplotlib charts, and self-contained HTML reports.
+katsustats is a Python library and CLI for generating backtest reports from financial return series. It takes a Polars DataFrame with `["date", "returns"]` columns (or a pandas DataFrame/Series) and produces summary metrics, drawdown analysis, matplotlib charts, and self-contained HTML, JSON, or Markdown reports.
 
 ## Architecture
 
@@ -10,9 +10,9 @@ Functional design in `src/katsustats/`:
 
 - `stats.py` — Pure metric computation (Sharpe, CAGR, drawdowns, etc.)
 - `plots.py` — Matplotlib chart generation (13 chart types)
-- `reports.py` — Orchestration: `full()` for dict output, `html()` for HTML report
+- `reports.py` — Orchestration: `full()` for dict output, `html()` for self-contained HTML, `json()` for structured JSON, `markdown()` for Markdown tables
 - `_dataframe.py` — Input normalisation: `ensure_polars()` converts pandas DataFrames, pandas Series (with DatetimeIndex), and Polars DataFrames to the canonical `["date", "returns"]` Polars frame
-- `__main__.py` — CLI entry point (`katsustats report`); reads CSV/Parquet and calls `reports.html()`
+- `__main__.py` — CLI entry point (`katsustats report`); reads CSV/Parquet and dispatches to `reports.html()`, `reports.json()`, or `reports.markdown()` via `--format`
 
 No classes. All public functions accept a Polars DataFrame, pandas DataFrame, or pandas Series with `date` and `returns` data.
 


### PR DESCRIPTION
## Summary

- `reports.py` exposes four output functions (`full`, `html`, `json`, `markdown`) but CLAUDE.md only documented `full` and `html`
- `__main__.py` dispatches to the correct report function via `--format html|json|markdown`; the old description incorrectly said it "calls `reports.html()`"
- Project overview now mentions HTML, JSON, and Markdown as supported output formats

## What was audited

All three repos (kabubot, cryptobot, katsustats) were checked against their actual codebase state:

- **kabubot**: CLAUDE.md is accurate — nav table entries verified, slash commands match `.claude/commands/`, `run_*.sh` deployment scripts confirmed present
- **cryptobot**: CLAUDE.md is accurate — strategies list matches `src/strategies/`, `run_*.sh` files confirmed, package namespace misspelling documented correctly
- **katsustats**: Three lines in the Architecture section were outdated (this PR)

## Test plan

- [ ] Verify `reports.py` contains `full()`, `html()`, `json()`, `markdown()` functions
- [ ] Verify `__main__.py` dispatches on `--format` flag rather than hard-coding `reports.html()`
- [ ] CI passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ceo1hdgHNPFKYCrrbjoeXc)_