### PR TITLE
docs: add /code-simplify to Slash Commands in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,3 +59,4 @@ CI runs on every PR and push to main (`.github/workflows/ci.yml`). All tests and
 ## Slash Commands (Claude Code)
 
 - `/publish` — cut a new PyPI release (bumps version, commits, creates GitHub release that triggers the publish workflow)
+- `/code-simplify` — refactor recently changed code for clarity and consistency without changing behavior


### PR DESCRIPTION
## Summary

- Add `/code-simplify` to the Slash Commands section of `CLAUDE.md`

The skill is defined in `.github/skills/code-simplify/SKILL.md` and is available for use, but was not listed in the agent-facing reference.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Szk1pbJ6gTJj5BraPCbFCW)_